### PR TITLE
fix(core): bound cluster_scan by the client's request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Bound `cluster_scan` by the client's `request_timeout`, as every other command path already is. A primary that stopped answering while still in the slot map left `scan()` pending indefinitely with no error raised to the caller. Each scan iteration is now bounded, and the cursor survives a timeout so callers can resume. ([#6824](https://github.com/valkey-io/valkey-glide/issues/6824))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Core: Bound `cluster_scan` by the client's `request_timeout`, as every other command path already is. A primary that stopped answering while still in the slot map left `scan()` pending indefinitely with no error raised to the caller. Each scan iteration is now bounded, and the cursor survives a timeout so callers can resume. ([#6824](https://github.com/valkey-io/valkey-glide/issues/6824))
+* Core/Java: Bound `cluster_scan` by the client's `request_timeout`, as every other command path already is. A primary that stopped answering while still in the slot map left `scan()` pending indefinitely with no error raised to the caller. Each scan iteration is now bounded, and the cursor survives a timeout so callers can resume. In Java, a scan that hits the bound raises `TimeoutException` rather than `RequestException`. ([#6824](https://github.com/valkey-io/valkey-glide/issues/6824))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))
 * Core/FFI: Strip brackets from IPv6 address literals in `create_client_from_uri` so bracketed hosts (e.g. `redis://[::1]:6379`) resolve correctly. `url::Url::host_str()` returns the literal with its surrounding brackets (`[::1]`), which `tokio::net::lookup_host` cannot resolve, causing connections to IPv6 literals to hang until the connect timeout. The URI parser now uses the unbracketed canonical form via `Ipv6Addr::to_string()`.

--- a/glide-core/redis-rs/redis/src/cluster_async/mod.rs
+++ b/glide-core/redis-rs/redis/src/cluster_async/mod.rs
@@ -62,7 +62,7 @@ use std::{
     net::{IpAddr, SocketAddr},
     pin::Pin,
     sync::{
-        atomic::{self, AtomicIsize, AtomicUsize, Ordering},
+        atomic::{self, AtomicBool, AtomicIsize, AtomicUsize, Ordering},
         Arc,
     },
     task::{self, Poll},
@@ -1554,6 +1554,24 @@ fn fail_queued_senders<C>(
     failed
 }
 
+/// Holds `SlotRefreshState::in_progress` for the duration of a slot refresh and
+/// clears it on drop.
+///
+/// The refresh awaits network I/O while holding the flag, so its future can be
+/// dropped part-way through -- `cluster_scan` bounds it by the client's request
+/// timeout. Clearing the flag on drop keeps a cancelled refresh from leaving it
+/// set, which would make every later refresh return early as though another one
+/// were still running.
+struct SlotRefreshInProgressGuard<'a> {
+    in_progress: &'a AtomicBool,
+}
+
+impl Drop for SlotRefreshInProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.in_progress.store(false, Ordering::Relaxed);
+    }
+}
+
 impl<C> ClusterConnInner<C>
 where
     C: ConnectionLike + Connect + Clone + Send + Sync + 'static,
@@ -2542,6 +2560,7 @@ where
             log_warn_lazy!("topology_refresh", "Concurrent slot refresh rejected by compare_exchange (another refresh is already in progress)");
             return Ok(());
         }
+        let _in_progress_guard = SlotRefreshInProgressGuard { in_progress };
         let acquire_elapsed = acquire_start.elapsed();
         if acquire_elapsed > Duration::from_millis(100) {
             log_warn_lazy!(
@@ -2608,7 +2627,6 @@ where
             })
             .await;
         }
-        in_progress.store(false, Ordering::Relaxed);
         res
     }
 
@@ -5307,5 +5325,39 @@ mod is_circular_moved_redirect_tests {
             ),
             "Without resolver, IP vs hostname won't be detected as circular"
         );
+    }
+}
+
+#[cfg(test)]
+mod slot_refresh_in_progress_guard_tests {
+    use super::{AtomicBool, Ordering, SlotRefreshInProgressGuard};
+
+    #[test]
+    fn clears_the_flag_when_the_scope_ends() {
+        let in_progress = AtomicBool::new(true);
+        {
+            let _guard = SlotRefreshInProgressGuard {
+                in_progress: &in_progress,
+            };
+            assert!(in_progress.load(Ordering::Relaxed));
+        }
+        assert!(!in_progress.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn clears_the_flag_when_the_scope_ends_early() {
+        let in_progress = AtomicBool::new(true);
+        let run = |cancel: bool| {
+            let _guard = SlotRefreshInProgressGuard {
+                in_progress: &in_progress,
+            };
+            if cancel {
+                // Stands in for the refresh future being dropped part-way through.
+                return "cancelled";
+            }
+            "completed"
+        };
+        assert_eq!(run(true), "cancelled");
+        assert!(!in_progress.load(Ordering::Relaxed));
     }
 }

--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -1599,27 +1599,35 @@ impl Client {
         let scan_state_cursor_clone = scan_state_cursor.clone();
         let cluster_scan_args_clone = cluster_scan_args.clone(); // Assuming ClusterScanArgs is Clone
 
-        // Check and initialize if lazy *inside* the async block
+        // Initialize a lazy client before the bound starts, as send_command does.
         let client = self.get_or_initialize_client().await?;
 
-        match client {
-            ClientWrapper::Standalone(_) => {
-                unreachable!("Cluster scan is not supported in standalone mode")
+        // Bound the scan by the client's configured request timeout, as every other
+        // command path is. The SCAN commands underneath carry no per-command response
+        // timeout, so they fall back to the connection default of Duration::MAX.
+        // tokio::time::timeout drops the inner future on expiry, which also ends the
+        // retry loop in try_scan rather than leaving it spinning.
+        run_with_timeout(Some(self.request_timeout), async move {
+            match client {
+                ClientWrapper::Standalone(_) => {
+                    unreachable!("Cluster scan is not supported in standalone mode")
+                }
+                ClientWrapper::Cluster { mut client, .. } => {
+                    let (cursor, keys) = client
+                        .cluster_scan(scan_state_cursor_clone, cluster_scan_args_clone) // Use clones
+                        .await?;
+                    let cluster_cursor_id = if cursor.is_finished() {
+                        Value::BulkString(FINISHED_SCAN_CURSOR.into()) // Use constant
+                    } else {
+                        Value::BulkString(insert_cluster_scan_cursor(cursor).into())
+                    };
+                    Ok(Value::Array(vec![cluster_cursor_id, Value::Array(keys)]))
+                }
+                // Lazy case is now handled by the initial check
+                ClientWrapper::Lazy(_) => unreachable!("Lazy client should have been initialized"),
             }
-            ClientWrapper::Cluster { mut client, .. } => {
-                let (cursor, keys) = client
-                    .cluster_scan(scan_state_cursor_clone, cluster_scan_args_clone) // Use clones
-                    .await?;
-                let cluster_cursor_id = if cursor.is_finished() {
-                    Value::BulkString(FINISHED_SCAN_CURSOR.into()) // Use constant
-                } else {
-                    Value::BulkString(insert_cluster_scan_cursor(cursor).into())
-                };
-                Ok(Value::Array(vec![cluster_cursor_id, Value::Array(keys)]))
-            }
-            // Lazy case is now handled by the initial check
-            ClientWrapper::Lazy(_) => unreachable!("Lazy client should have been initialized"),
-        }
+        })
+        .await
     }
 
     fn get_transaction_values(

--- a/glide-core/src/errors.rs
+++ b/glide-core/src/errors.rs
@@ -47,4 +47,35 @@ mod tests {
         ));
         assert_eq!(error_type(&err), RequestErrorType::CircuitBreakerOpen);
     }
+
+    #[test]
+    fn request_timeout_error_type() {
+        let err: redis::RedisError = std::io::Error::from(std::io::ErrorKind::TimedOut).into();
+        assert_eq!(error_type(&err), RequestErrorType::Timeout);
+    }
+
+    /// A connection-class error mapped to `ClientError` reports as `Unspecified`, which
+    /// keeps it out of the `Disconnect` bucket. Java raises `Disconnect` as
+    /// `ClosingException` and closes the client on it, so a binding that remaps an error
+    /// to `ClientError` is choosing not to trigger that.
+    #[test]
+    fn client_error_is_unspecified_not_disconnect() {
+        let err = redis::RedisError::from((
+            redis::ErrorKind::ClientError,
+            "Cluster scan execution failed",
+            "connection reset".to_string(),
+        ));
+        assert_eq!(error_type(&err), RequestErrorType::Unspecified);
+    }
+
+    /// `is_timeout` reads the error's inner representation, not its `ErrorKind`, so a
+    /// timeout that is rebuilt through `RedisError::from((kind, ..))` stops reporting as
+    /// one. A binding that bridges a timeout must pass it through rather than rebuild it.
+    #[test]
+    fn rebuilding_a_timeout_loses_its_type() {
+        let err: redis::RedisError = std::io::Error::from(std::io::ErrorKind::TimedOut).into();
+        let rebuilt =
+            redis::RedisError::from((err.kind(), "Cluster scan execution failed", err.to_string()));
+        assert_eq!(error_type(&rebuilt), RequestErrorType::Unspecified);
+    }
 }

--- a/glide-core/tests/test_cluster_client.rs
+++ b/glide-core/tests/test_cluster_client.rs
@@ -943,4 +943,78 @@ mod cluster_client_tests {
             );
         });
     }
+
+    /// `cluster_scan` must be bounded by the client's `request_timeout`, the way
+    /// every other command path is.
+    ///
+    /// Two things beneath it are unbounded. `send_scan` builds its `SCAN` command
+    /// without calling `set_response_timeout`, so the command inherits the
+    /// connection default, which is `Duration::MAX`; and the retry loop in
+    /// `try_scan` has neither a deadline nor a retry counter. A primary that
+    /// stops answering while still in the slot map therefore leaves the caller
+    /// waiting, with no error returned.
+    ///
+    /// This test blocks every primary with a busy script. Without the bound the
+    /// call does not settle and rstest kills the test at its own limit; with it,
+    /// the call returns a timeout error at `request_timeout`.
+    #[rstest]
+    #[serial_test::serial]
+    #[timeout(SHORT_CLUSTER_TEST_TIMEOUT)]
+    fn test_cluster_scan_is_bounded_by_request_timeout() {
+        const REQUEST_TIMEOUT_MS: u32 = 500;
+
+        block_on_all(async move {
+            let mut test_basics = setup_test_basics_internal(TestConfiguration {
+                cluster_mode: ClusterMode::Enabled,
+                request_timeout: Some(REQUEST_TIMEOUT_MS),
+                shared_server: false,
+                ..Default::default()
+            })
+            .await;
+
+            // Block every primary, so no scan iteration can be answered. The
+            // script keeps running server-side after this command times out,
+            // which is what leaves the nodes unresponsive for the scan below.
+            let mut blocking_client = test_basics.client.clone();
+            tokio::spawn(async move {
+                let mut cmd = redis::cmd("EVAL");
+                cmd.arg(
+                    r#"
+                    while (true)
+                    do
+                    redis.call('ping')
+                    end
+                "#,
+                )
+                .arg("0");
+                let _ = blocking_client
+                    .send_command(
+                        &mut cmd,
+                        Some(RoutingInfo::MultiNode((
+                            MultipleNodeRoutingInfo::AllMasters,
+                            None,
+                        ))),
+                    )
+                    .await;
+            });
+
+            // Let the scripts take hold before scanning.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+
+            let cursor = redis::ScanStateRC::new();
+            let args = redis::ClusterScanArgs::builder().build();
+
+            let started = std::time::Instant::now();
+            let result = test_basics.client.cluster_scan(&cursor, args).await;
+            let elapsed = started.elapsed();
+
+            let err = result.expect_err("cluster_scan should fail while every primary is blocked");
+            assert!(err.is_timeout(), "expected a timeout error, got: {err}");
+            assert!(
+                elapsed < Duration::from_millis(REQUEST_TIMEOUT_MS as u64) * 4,
+                "cluster_scan took {elapsed:?}, which is not bounded by the \
+                 {REQUEST_TIMEOUT_MS}ms request timeout",
+            );
+        });
+    }
 }

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -2358,16 +2358,30 @@ pub extern "system" fn Java_glide_internal_GlideNativeBridge_executeClusterScanA
                     }
                     let scan_args = scan_args_builder.build();
 
-                    // Execute cluster scan
+                    // Execute cluster scan.
+                    //
+                    // A timeout is passed through as it is. `RedisError::is_timeout` reads the
+                    // error's inner representation rather than its `ErrorKind`, so rebuilding a
+                    // timeout drops the marker whichever kind is used, and `error_type` reports
+                    // `RequestErrorType::Unspecified` -- Java then raises `RequestException`
+                    // rather than `TimeoutException`.
+                    //
+                    // Every other error keeps the `ClientError` mapping. Passing those through
+                    // would sort the unrecoverable kinds into `RequestErrorType::Disconnect`,
+                    // which Java raises as `ClosingException`, and that closes the client.
                     let result = client
                         .cluster_scan(&scan_state_cursor, scan_args)
                         .await
                         .map_err(|e| {
-                            redis::RedisError::from((
-                                redis::ErrorKind::ClientError,
-                                "Cluster scan execution failed",
-                                e.to_string(),
-                            ))
+                            if e.is_timeout() {
+                                e
+                            } else {
+                                redis::RedisError::from((
+                                    redis::ErrorKind::ClientError,
+                                    "Cluster scan execution failed",
+                                    e.to_string(),
+                                ))
+                            }
                         });
 
                     // binary_mode = !expect_utf8


### PR DESCRIPTION
### Summary

`cluster_scan` is the only command path in `glide-core` that applies no timeout. `send_command`, `send_transaction` and `send_pipeline` each bound themselves; `cluster_scan` awaited its inner call unwrapped. A primary that stopped answering while still in the slot map therefore left `scan()` pending, with no error returned to the caller.

This wraps the `cluster_scan` body in `run_with_timeout`, the helper `send_transaction` and `send_pipeline` already use, bounded by the client's configured `request_timeout`.

### Issue link

This Pull Request is linked to issue: [(core): cluster_scan is not bounded by requestTimeout and never settles when a primary is unreachable](https://github.com/valkey-io/valkey-glide/issues/6824)
Closes #6824

A maintainer confirmed on the issue that a PR was welcome before this was written.

### Features / Behaviour Changes

`scan()` now returns a timeout error at `request_timeout` instead of never settling. This brings the implementation in line with the published documentation, which already describes `requestTimeout` as covering every request with no exclusion for scan: _"the period during which the client will await the completion of a request. This includes the process of sending the request, waiting for a response from the node(s), and any necessary reconnection or retry attempts."_

The bound applies per scan iteration. `Client::cluster_scan` handles a single `client.scan(cursor)` call, returning one cursor and one page of keys, so a long scan over a large keyspace is unaffected — each iteration gets its own budget, exactly as each command does.

The cursor survives the timeout, so a caller that times out can resume rather than restart.

One thing worth reviewer attention: an iteration that crosses a node boundary also performs a topology refresh inside that same budget, and `request_timeout` defaults to 250 ms (`DEFAULT_RESPONSE_TIMEOUT`). A scan that previously rode out a transient node error may now surface a timeout instead. That is the intended trade — a bounded error the caller can see and retry, rather than an unbounded wait — but it is a behaviour change, and I am happy to add a note to the `scan` docs across the wrappers if you would like one.

### Implementation

The mechanism, traced on `main`:

| Step | Location                                                           | What it establishes                                                                                                    |
| ---- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
| 1    | `glide-core/src/client/mod.rs:1173`                                | `send_command` sets a **per-command** bound: `cmd.set_response_timeout(request_timeout)`                               |
| 2    | `glide-core/redis-rs/redis/src/aio/multiplexed_connection.rs:1095` | The effective bound is `cmd.response_timeout().unwrap_or(self.response_timeout)`                                       |
| 3    | `glide-core/redis-rs/redis/src/commands/cluster_scan.rs`           | `send_scan` builds its `SCAN` without calling `set_response_timeout`, so the command carries no per-command bound      |
| 4    | `glide-core/redis-rs/redis/src/cluster_client.rs:198`              | The connection default is `response_timeout.unwrap_or(Duration::MAX)`, and `glide-core` sets only `connection_timeout` |

So the `SCAN` falls through every bound there is. A local run has GLIDE reporting it in its own words — for a `GET` on the client, `response_timeout=2s`; for a `scan()` on the same client, `response_timeout=18446744073709551615.999999999s`, which is `Duration::MAX`.

Separately, when the connection is dropped rather than frozen, the retry loop in `try_scan` spins with neither a deadline nor a retry counter. `run_with_timeout` uses `tokio::time::timeout`, which drops the inner future on expiry, so the bound ends that loop too.

`ClusterScan` has no timeout field in `command_request.proto`, so `self.request_timeout` is the only source and there is no per-call override to honour. If a per-call scan timeout is wanted, that is a proto change and a separate discussion.

**Third commit — please review this one closely.** Bounding the scan puts `refresh_slots_and_subscriptions_with_retries_inner` on a cancellable future for the first time. It took `SlotRefreshState::in_progress` with a `compare_exchange` and released it with a plain `store` at the end of the function, awaiting network I/O in between. Dropping that future part-way through left the flag set with no refresh running, after which every later refresh took the early return, logged a warning and returned `Ok(())` — the slot map silently stopped being refreshed for the lifetime of the process. Every other caller reaches that code from a spawned task or from client construction, so nothing could drop the future before this change. The commit holds the flag in a guard and clears it in `Drop`.

The scan bound itself sits in `glide-core` rather than in the `redis-rs` fork where the `SCAN` is built, keeping it at the layer that already owns per-command timeouts.

### Limitations

Verified on `darwin-arm64` only.

The added `glide-core` test blocks every primary with a busy script, which exercises the case where the caller never gets an answer; it does not separately distinguish the `Duration::MAX` blocked read from the `try_scan` retry loop. One bound covers both.

### Testing

The test was written first and run before the fix, so the failure is recorded rather than assumed. The failing result is the one observed when the commit was written; the passing result is from the current branch, rebased onto `main`.

| Commit                                                          | `test_cluster_scan_is_bounded_by_request_timeout`                         |
| --------------------------------------------------------------- | ------------------------------------------------------------------------- |
| `test(core): add failing test for unbounded cluster_scan`       | `FAILED` — the call does not settle and rstest kills it at its 50 s limit |
| `fix(core): bound cluster_scan by the client's request timeout` | `ok`, 20-23 s across four runs                                            |

The `in_progress` guard is covered by two unit tests in `cluster_async`, for the normal and the early exit.

Beyond the repo's own tests, the behaviour was reproduced against a local three-primary Valkey cluster (no replicas, so a failed primary keeps its slots) with `requestTimeout: 2000`, breaking one primary while it remained in the slot map:

| Fault          | `scan()`                                            | Control `GET` on the same broken node   |
| -------------- | --------------------------------------------------- | --------------------------------------- |
| `docker pause` | pending 120,075 ms (60x the timeout), never settled | rejected at 2,003 ms, `TimeoutError`    |
| `docker kill`  | pending 120,221 ms (60.1x), never settled           | rejected at 1,282 ms, `ConnectionError` |

Both scans were still pending when the harness stopped waiting, and both resolved as soon as the node came back. The control `GET` staying bounded throughout is what isolates this to the scan path.

With the fix, the scan rejects after 2,004 ms against 2,003 ms for the `GET` — the same 3-4 ms of overshoot as every other command path. The cursor held before the failed call resumed to completion: 300 keys read before the fault and 4,702 after it, against 5,002 seeded, losing nothing.

Under `docker kill` the fix also ends the spin: ~5,100 topology refreshes per second for the full 120 s unpatched, versus the loop gone one second after the scan rejects. The debug log for the run fell from 455 MB to 8 MB.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`cargo fmt --all --check` and `cargo clippy --all-targets -D warnings`, clean on `glide-core` and on the `redis` crate).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary

### Questions for reviewers

**Circuit breaker.** `cluster_scan` neither checks the breaker before dispatch (`glide-core/src/client/mod.rs:1116`) nor reports to it afterwards (`glide-core/src/client/mod.rs:1333-1378`), so the timeout this PR adds never reaches it. I agree it should count. I have left it out for now because each scan iteration carries its own `request_timeout` budget — 250 ms by default, and a node-boundary iteration spends part of that on a topology refresh — so counting scan timeouts may trip the breaker sooner than counting ordinary command timeouts. That felt like your call. Happy to add it here.

Scans still being admitted while the breaker is open predates this change, so I have left it out of scope.

**`invoke_script` has the same error-bridging defect.** `java/src/lib.rs:2087` rebuilds every error as `ClientError`, losing the timeout kind exactly as `cluster_scan`. So a script exceeding `request_timeout` should already raise `RequestException` instead of `TimeoutException`. Same pattern at `java/src/lib.rs:2149` and `:2198`. I left it untouched, let me know if you'd like me to include it.
