### PR TITLE
perf(go): drop get_response_type_string FFI call from response type checks

### DIFF
--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -2677,26 +2677,6 @@ pub unsafe extern "C" fn free_connection_response(
     }
 }
 
-/// Provides the string mapping for the ResponseType enum.
-///
-/// Important: the returned pointer is a pointer to a constant string and should not be freed.
-#[unsafe(no_mangle)]
-pub extern "C" fn get_response_type_string(response_type: ResponseType) -> *const c_char {
-    let c_str = match response_type {
-        ResponseType::Null => c"Null",
-        ResponseType::Int => c"Int",
-        ResponseType::Float => c"Float",
-        ResponseType::Bool => c"Bool",
-        ResponseType::String => c"String",
-        ResponseType::Array => c"Array",
-        ResponseType::Map => c"Map",
-        ResponseType::Sets => c"Sets",
-        ResponseType::Ok => c"Ok",
-        ResponseType::Error => c"Error",
-    };
-    c_str.as_ptr()
-}
-
 /// Deallocates a `CommandResponse`.
 ///
 /// This function also frees the contained string_value and array_value. If the string_value and array_value are null pointers, the function returns and only the `CommandResponse` is freed.

--- a/go/response_handlers.go
+++ b/go/response_handlers.go
@@ -19,14 +19,40 @@ import (
 	"github.com/valkey-io/valkey-glide/go/v2/options"
 )
 
+// responseTypeName returns the name of a ResponseType, for error messages only.
+func responseTypeName(responseType uint32) string {
+	switch responseType {
+	case uint32(C.Null):
+		return "Null"
+	case uint32(C.Int):
+		return "Int"
+	case uint32(C.Float):
+		return "Float"
+	case uint32(C.Bool):
+		return "Bool"
+	case uint32(C.String):
+		return "String"
+	case uint32(C.Array):
+		return "Array"
+	case uint32(C.Map):
+		return "Map"
+	case uint32(C.Sets):
+		return "Sets"
+	case uint32(C.Ok):
+		return "Ok"
+	case uint32(C.Error):
+		return "Error"
+	}
+	return fmt.Sprintf("Unknown(%d)", responseType)
+}
+
 func checkResponseType(response *C.struct_CommandResponse, expectedType C.ResponseType, isNilable bool) error {
 	expectedTypeInt := uint32(expectedType)
-	expectedTypeStr := C.get_response_type_string(expectedTypeInt)
 
 	if !isNilable && response == nil {
 		return fmt.Errorf(
 			"unexpected return type from Valkey: got nil, expected %s",
-			C.GoString(expectedTypeStr),
+			responseTypeName(expectedTypeInt),
 		)
 	}
 
@@ -38,11 +64,10 @@ func checkResponseType(response *C.struct_CommandResponse, expectedType C.Respon
 		return nil
 	}
 
-	actualTypeStr := C.get_response_type_string(response.response_type)
 	return fmt.Errorf(
 		"unexpected return type from Valkey: got %s, expected %s",
-		C.GoString(actualTypeStr),
-		C.GoString(expectedTypeStr),
+		responseTypeName(response.response_type),
+		responseTypeName(expectedTypeInt),
 	)
 }
 

--- a/go/response_handlers_test.go
+++ b/go/response_handlers_test.go
@@ -1,0 +1,28 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+package glide
+
+import "testing"
+
+// Values mirror the ResponseType enum in lib.h; cgo cannot be used from _test.go files.
+func TestResponseTypeName(t *testing.T) {
+	cases := map[uint32]string{
+		0:  "Null",
+		1:  "Int",
+		2:  "Float",
+		3:  "Bool",
+		4:  "String",
+		5:  "Array",
+		6:  "Map",
+		7:  "Sets",
+		8:  "Ok",
+		9:  "Error",
+		99: "Unknown(99)",
+	}
+
+	for responseType, want := range cases {
+		if got := responseTypeName(responseType); got != want {
+			t.Errorf("responseTypeName(%d) = %q, want %q", responseType, got, want)
+		}
+	}
+}

--- a/python/glide-shared/glide_shared/_glide_ffi.py
+++ b/python/glide-shared/glide_shared/_glide_ffi.py
@@ -111,7 +111,6 @@ class _GlideFFI:
                 void* arena;
             } CommandResult;
 
-            const char* get_response_type_string(int response_type);
             void free_command_response(CommandResponse* command_response_ptr);
             void free_response_arena(void* arena_ptr);
             void free_command_result(CommandResult* command_result_ptr);


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

`checkResponseType` in `go/response_handlers.go` called the `get_response_type_string` FFI function on **every** response validation, including the happy path, purely to pre-format a type name that is only ever used when the check fails. Since `checkResponseType` guards essentially every decoded response, that is one wasted CGO hop per command.

The response type is already available numerically as `response.response_type` (the `ResponseType` discriminant, `0`-`9`) and is already compared numerically at the dispatch site, so the string was needed for diagnostics only. This PR replaces the FFI lookup with a Go `switch` over the C enum constants, evaluated only on the error paths, and deletes the now-unused FFI function.

### Issue link

This Pull Request is linked to issue: [[Task] Go - remove `get_response_type_string`](https://github.com/valkey-io/valkey-glide/issues/3935)
Closes #3935

### Features / Behaviour Changes

No behavioural change. `checkResponseType`'s branching is unchanged and every error message is byte-identical to before:

- `unexpected return type from Valkey: got nil, expected <T>`
- `unexpected return type from Valkey: got <A>, expected <T>`

Type names (`Null`, `Int`, `Float`, `Bool`, `String`, `Array`, `Map`, `Sets`, `Ok`, `Error`) are unchanged, and an out-of-range discriminant now formats as `Unknown(<n>)` instead of dereferencing whatever the FFI returned.

`checkResponseType` now makes **zero** CGO calls.

### Implementation

Four files.

**`go/response_handlers.go`**: new `responseTypeName(uint32) string` helper, a `switch` over `uint32(C.Null)` through `uint32(C.Error)` with an `Unknown(%d)` fallback. `checkResponseType` calls it only on the two error paths; the happy path and the nilable short-circuit now do no name resolution at all.

**`ffi/src/lib.rs`**: `get_response_type_string` deleted along with its doc comment and `#[unsafe(no_mangle)]` attribute. `c_char` is still used by 50+ other sites in the file, so the import stays.

**`python/glide-shared/glide_shared/_glide_ffi.py`**: removed the dead CFFI declaration `const char* get_response_type_string(int response_type);`. Nothing in `python/` ever called it.

**`go/response_handlers_test.go`**: new test (see Testing).

`go/lib.h` is generated by `cbindgen` (`go/Makefile: gen-c-bindings`) and is `.gitignore`d, so the header declaration disappears on the next build rather than being edited by hand. Verified locally: after `make build-glide-client` the symbol is gone from the regenerated header.

#### Notes for reviewers

**Go was the only consumer.** Verified across the whole repo:

| Location | Kind |
|---|---|
| `ffi/src/lib.rs:2684` | definition (deleted) |
| `go/response_handlers.go:24,41` | the only two call sites (removed) |
| `python/glide-shared/glide_shared/_glide_ffi.py:114` | CFFI declaration, never called (deleted) |
| `go/lib.h` | generated header declaration (regenerated) |
| Java, Node | zero references |

Java and Node never touch this symbol. Both pattern-match on the Rust-side `redis::Value` enum instead. Python-sync reads the numeric `response_type` field directly (`python/glide-sync/glide_sync/glide_client.py`), which is exactly the approach Go now uses for naming too.

### Limitations

None. Scope is one FFI function and its callers.

### Testing

**New unit test**: `go/response_handlers_test.go` covers `responseTypeName` for all ten `ResponseType` values plus the `Unknown(99)` fallback.

Note that the test asserts against the numeric literals `0`-`9` rather than the `C.*` constants. Go does not permit `import "C"` inside `_test.go` files (`use of cgo in test ... not supported`), so cgo-dependent assertions have to live in non-test files. This matches the existing convention in `go/gostringn_copy_test.go`, which keeps cgo out of the test file and calls helpers defined in package code. The literals double as a check that the enum values really are `0`-`9` as documented in `go/lib.h`. `checkResponseType`'s branching is unchanged by this PR and remains covered by the integration suite.

Run locally on `fix/go-remove-get-response-type-string`:

```
$ make build-glide-client          # Rust release build + cbindgen regen, exit 0
$ grep -c get_response_type_string lib.h
0
$ go build ./...                   # exit 0
$ go vet ./...                     # exit 0
$ gofumpt -l response_handlers.go response_handlers_test.go       # (no output)
$ golines -l --shorten-comments -m 127 response_handlers.go response_handlers_test.go   # (no output)
$ staticcheck .                    # (no output)

$ go test . -run TestResponseTypeName -v
=== RUN   TestResponseTypeName
--- PASS: TestResponseTypeName (0.00s)
ok  github.com/valkey-io/valkey-glide/go/v2  0.616s

$ go test . ./config ./options ./internal/... -run Test
ok  github.com/valkey-io/valkey-glide/go/v2                 2.374s
ok  github.com/valkey-io/valkey-glide/go/v2/config          1.842s
ok  github.com/valkey-io/valkey-glide/go/v2/options         0.843s
ok  github.com/valkey-io/valkey-glide/go/v2/internal/utils  1.267s
```

**Integration, against live servers, standalone + cluster.** Commands chosen to exercise every `ResponseType` variant (`String`, `Ok`, `Int`, `Float`, `Bool`, `Array`, `Map`, `Sets`, `Null`):

```
$ go test ./integTest/... -run TestGlideTestSuite \
    -testify.m 'TestSetAndGet|TestIncr|TestHGetAll|TestLRange|TestSMembers|TestZAdd|TestType|TestExists|TestGetDel|TestObjectEncoding|TestIncrByFloat|TestMGet|TestInfo|TestConfigGet'
ok  github.com/valkey-io/valkey-glide/go/v2/integTest  35.442s
```

50 subtests passed, 0 failed, each across both `glide.Client` and `glide.ClusterClient`. `TestPool*` and `TestScope*` also run clean (6 passed, 0 failed).

**Python**: `python3 -m py_compile python/glide-shared/glide_shared/_glide_ffi.py` succeeds, and a repo-wide search confirms zero remaining references to `get_response_type_string` outside the generated header.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated. _(New `TestResponseTypeName`; the surrounding `checkResponseType` logic is unchanged and covered by the integration suite.)_
- [ ] CHANGELOG.md and documentation files are updated. _(Not added, since this is an internal FFI/perf refactor with no user-visible API or behaviour change. Happy to add a `### Changes` entry if maintainers prefer one.)_
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). _(`go vet`, `gofumpt`, `golines`, `staticcheck`, all clean on the changed files.)_
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary _(Not necessary, since no public API or behaviour changes.)_
