### PR TITLE
fix(java): serialize circuit breaker, AZ readFrom, clientAZ and lazyConnect for pool clients (#6897)

### DIFF
--- a/java/client/src/main/java/glide/api/models/pool/ClientPool.java
+++ b/java/client/src/main/java/glide/api/models/pool/ClientPool.java
@@ -9,6 +9,7 @@ import glide.api.models.configuration.BackoffStrategy;
 import glide.api.models.configuration.BaseClientConfiguration;
 import glide.api.models.configuration.GlideClientConfiguration;
 import glide.api.models.configuration.GlideClusterClientConfiguration;
+import glide.api.models.configuration.ClientCircuitBreakerConfiguration;
 import glide.api.models.configuration.ServerCredentials;
 import glide.api.models.exceptions.ClosingException;
 import glide.ffi.resolvers.GlidePoolResolver;
@@ -275,10 +276,52 @@ public class ClientPool implements AutoCloseable {
             String rf = config.getReadFrom().name();
             if ("PRIMARY".equals(rf)) b.setReadFrom(ReadFrom.Primary);
             else if ("PREFER_REPLICA".equals(rf)) b.setReadFrom(ReadFrom.PreferReplica);
+            else if ("AZ_AFFINITY".equals(rf)) b.setReadFrom(ReadFrom.AZAffinity);
+            else if ("AZ_AFFINITY_REPLICAS_AND_PRIMARY".equals(rf)) {
+                b.setReadFrom(ReadFrom.AZAffinityReplicasAndPrimary);
+            } else if ("ALL_NODES".equals(rf)) b.setReadFrom(ReadFrom.AllNodes);
+        }
+
+        // Serialize the client circuit breaker configuration (already validated by the
+        // builder) so pooled clients fail fast exactly like non-pooled clients. A
+        // pooled client silently ignoring an unhealthy core defeats the purpose of a
+        // bounded pool under sustained failures (#6897).
+        ClientCircuitBreakerConfiguration cbConfig = config.getClientCircuitBreakerConfiguration();
+        if (cbConfig != null) {
+            if (cbConfig.getWindowSizeMs() <= 0) {
+                throw new IllegalArgumentException("windowSizeMs must be positive");
+            }
+            if (cbConfig.getFailureRateThreshold() <= 0.0f || cbConfig.getFailureRateThreshold() > 1.0f) {
+                throw new IllegalArgumentException(
+                        "failureRateThreshold must be between 0.0 (exclusive) and 1.0 (inclusive)");
+            }
+            if (cbConfig.getMinErrors() <= 0) {
+                throw new IllegalArgumentException("minErrors must be positive");
+            }
+            if (cbConfig.getOpenTimeoutMs() <= 0) {
+                throw new IllegalArgumentException("openTimeoutMs must be positive");
+            }
+            if (cbConfig.getConsecutiveSuccesses() <= 0) {
+                throw new IllegalArgumentException("consecutiveSuccesses must be positive");
+            }
+            b.setClientCircuitBreaker(
+                    ClientCircuitBreakerConfig.newBuilder()
+                            .setWindowSizeMs(cbConfig.getWindowSizeMs())
+                            .setFailureRateThreshold(cbConfig.getFailureRateThreshold())
+                            .setMinErrors(cbConfig.getMinErrors())
+                            .setOpenTimeoutMs(cbConfig.getOpenTimeoutMs())
+                            .setCountTimeouts(cbConfig.isCountTimeouts())
+                            .setConsecutiveSuccesses(cbConfig.getConsecutiveSuccesses())
+                            .build());
         }
 
         if (config.getClientName() != null) b.setClientName(config.getClientName());
+        if (config.getClientAZ() != null) b.setClientAz(config.getClientAZ());
         if (config.getDatabaseId() != null) b.setDatabaseId(config.getDatabaseId());
+
+        // lazyConnect: deliberately serialized unconditionally so pooled clients match
+        // the canonical ConnectionManager behavior (default false, no-op when unset).
+        b.setLazyConnect(config.isLazyConnect());
 
         if (config.getProtocol() != null) {
             if ("RESP2".equals(config.getProtocol().name())) b.setProtocol(ProtocolVersion.RESP2);
@@ -291,6 +334,7 @@ public class ClientPool implements AutoCloseable {
             if (rs.getNumOfRetries() != null) r.setNumberOfRetries(rs.getNumOfRetries());
             if (rs.getFactor() != null) r.setFactor(rs.getFactor());
             if (rs.getExponentBase() != null) r.setExponentBase(rs.getExponentBase());
+            if (rs.getJitterPercent() != null) r.setJitterPercent(rs.getJitterPercent());
             b.setConnectionRetryStrategy(r.build());
         }
 


### PR DESCRIPTION
## Why

`ClientPool.serializeConnectionRequest` hand-builds the `ConnectionRequest` with a partial copy of the canonical serialization in `ConnectionManager`, silently dropping several supported configuration fields **for every client borrowed from the pool** (#6897). No error or warning is raised.

Concretely, pooled clients ignore:

- **`clientCircuitBreakerConfiguration(...)`** — the client-level circuit breaker is never installed, so pooled clients never fail fast and a `CircuitBreakerException` is never thrown, even under sustained failures.
- **`readFrom(AZ_AFFINITY)`, `readFrom(AZ_AFFINITY_REPLICAS_AND_PRIMARY)`, `readFrom(ALL_NODES)`** — only `PRIMARY` and `PREFER_REPLICA` were serialized; the other modes fell through and the pool read as if `PRIMARY`.
- **`clientAz(...)`** — dropped, so AZ affinity could not work even if the read mode were serialized.
- **`lazyConnect(...)`** — dropped.
- Reconnect strategy **`jitterPercent`** — also dropped.

## What changed

`java/client/src/main/java/glide/api/models/pool/ClientPool.java` — `serializeConnectionRequest` now mirrors the canonical `ConnectionManager` serialization:

- Read-from mapping extended to all five modes (`AZAffinity`, `AZAffinityReplicasAndPrimary`, `AllNodes`).
- Circuit breaker config serialized with the same validation as `ConnectionManager` (window size, failure rate threshold bounds, min errors, open timeout, consecutive successes).
- `clientAZ` serialized when set.
- `lazyConnect` serialized unconditionally (matches canonical behavior; default `false` is a no-op in core).
- Reconnect strategy now includes `jitterPercent` when configured.

## Verification

- All referenced proto fields confirmed against `glide-core/src/protobuf/connection_request.proto` (`read_from`, `client_circuit_breaker`, `client_az`, `lazy_connect`, `jitter_percent`).
- Fix mechanism verified with a standalone logic harness: all 5 read-from modes map correctly, circuit-breaker serialization + validation behave, `clientAZ`/`lazyConnect`/`jitterPercent` are included, and untouched fields (client name, database id, protocol, reconnect base) keep working (8 assertions passed).

## Type of change

- [x] Bug fix
