### PR TITLE
chore(rust): Cargo.lock dashmap cleanup

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -790,22 +790,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1140,7 +1127,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -2260,7 +2247,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -581,9 +581,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -683,22 +683,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1024,7 +1011,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1060,7 +1047,7 @@ name = "glide-ffi"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "dashmap 6.1.0",
+ "dashmap",
  "glide-core",
  "lazy_static",
  "libc",
@@ -2164,7 +2151,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [dependencies]
 bytes = "1"
 libc = "0.2"
-dashmap = "=6.2.1"
+dashmap = "~6.2.1"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }
 glide-core = { path = "../glide-core", features = ["proto"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "rlib", "cdylib"]
 [dependencies]
 bytes = "1"
 libc = "0.2"
-dashmap = "6"
+dashmap = "=6.2.1"
 protobuf = { version = "3", features = [] }
 redis = { path = "../glide-core/redis-rs/redis", features = ["aio", "tokio-comp", "tokio-rustls-comp"] }
 glide-core = { path = "../glide-core", features = ["proto"] }

--- a/ffi/miri-tests/Cargo.lock
+++ b/ffi/miri-tests/Cargo.lock
@@ -655,22 +655,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -990,7 +977,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -2147,7 +2134,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/ffi/miri-tests/mock-glide-core/Cargo.lock
+++ b/ffi/miri-tests/mock-glide-core/Cargo.lock
@@ -655,22 +655,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -990,7 +977,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -2118,7 +2105,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/ffi/miri-tests/mock-redis/Cargo.lock
+++ b/ffi/miri-tests/mock-redis/Cargo.lock
@@ -230,9 +230,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -585,9 +585,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Valkey GLIDE Maintainers"]
 [dependencies]
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 bytes = "1"
-dashmap = "6"
+dashmap = "=6.2.1"
 futures = "^0.3"
 redis = { path = "./redis-rs/redis", features = [
     "aio",

--- a/glide-core/Cargo.toml
+++ b/glide-core/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Valkey GLIDE Maintainers"]
 [dependencies]
 uuid = { version = "1", features = ["v4", "fast-rng"] }
 bytes = "1"
-dashmap = "=6.2.1"
+dashmap = "~6.2.1"
 futures = "^0.3"
 redis = { path = "./redis-rs/redis", features = [
     "aio",

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -61,7 +61,7 @@ crc16 = { version = "0.4", optional = true }
 rand = { version = "0.9", optional = true }
 
 # Only needed for async cluster
-dashmap = { version = "=6.2.1", optional = true }
+dashmap = { version = "~6.2.1", optional = true }
 parking_lot = { version = "0.12", optional = true }
 
 async-trait = { version = "0.1", optional = true }

--- a/glide-core/redis-rs/redis/Cargo.toml
+++ b/glide-core/redis-rs/redis/Cargo.toml
@@ -61,7 +61,7 @@ crc16 = { version = "0.4", optional = true }
 rand = { version = "0.9", optional = true }
 
 # Only needed for async cluster
-dashmap = { version = "6", optional = true }
+dashmap = { version = "=6.2.1", optional = true }
 parking_lot = { version = "0.12", optional = true }
 
 async-trait = { version = "0.1", optional = true }

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -689,19 +689,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -1024,7 +1011,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -1061,7 +1048,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "dashmap 6.2.1",
+ "dashmap",
  "glide-core",
  "jni 0.21.1",
  "log",
@@ -2175,7 +2162,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.2.1",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -526,9 +526,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.225"
 serde_json = "1.0.149"
 # Additional dependencies for JNI implementation
 anyhow = "1.0"
-dashmap = "=6.2.1"
+dashmap = "~6.2.1"
 parking_lot = "0.12"
 scopeguard = "1.2"
 telemetrylib = { path = "../glide-core/telemetry"}

--- a/java/Cargo.toml
+++ b/java/Cargo.toml
@@ -24,7 +24,7 @@ serde = "1.0.225"
 serde_json = "1.0.149"
 # Additional dependencies for JNI implementation
 anyhow = "1.0"
-dashmap = "6.1.0"
+dashmap = "=6.2.1"
 parking_lot = "0.12"
 scopeguard = "1.2"
 telemetrylib = { path = "../glide-core/telemetry"}

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -547,9 +547,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -715,22 +715,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1030,7 +1017,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "futures",
  "futures-intrusive",
  "http 1.4.0",
@@ -2223,7 +2210,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",
@@ -3213,7 +3200,7 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "glide-core",
  "logger_core",
  "napi",

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -21,7 +21,7 @@ logger_core = { path = "../../logger_core" }
 telemetrylib = { path = "../../glide-core/telemetry" }
 byteorder = "1"
 bytes = "1"
-dashmap = "5"
+dashmap = "=6.2.1"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/node/rust-client/Cargo.toml
+++ b/node/rust-client/Cargo.toml
@@ -21,7 +21,7 @@ logger_core = { path = "../../logger_core" }
 telemetrylib = { path = "../../glide-core/telemetry" }
 byteorder = "1"
 bytes = "1"
-dashmap = "=6.2.1"
+dashmap = "~6.2.1"
 num-traits = "0.2"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/node/src/BaseClient.ts
+++ b/node/src/BaseClient.ts
@@ -2330,7 +2330,7 @@ export class BaseClient {
     ): PubSubMsg | null {
         let msg: PubSubMsg | null = null;
         const responsePointer = pushNotification.respPointer;
-        let nextPushNotificationValue: Record<string, unknown> = {};
+        let nextPushNotificationValue: Record<string, unknown>;
         const isStringDecoder =
             (decoder ?? this.defaultDecoder) === Decoder.String;
 

--- a/node/tests/OpenTelemetry.test.ts
+++ b/node/tests/OpenTelemetry.test.ts
@@ -43,6 +43,7 @@ function readAndParseSpanFile(path: string): {
     } catch (error: unknown) {
         throw new Error(
             `Failed to read or validate file: ${error instanceof Error ? error.message : String(error)}`,
+            { cause: error },
         );
     }
 

--- a/node/tests/ScanTest.test.ts
+++ b/node/tests/ScanTest.test.ts
@@ -74,7 +74,7 @@ describe("Scan GlideClusterClient", () => {
             ]);
             let cursor = new ClusterScanCursor();
             const allKeys: GlideString[] = [];
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
 
             while (!cursor.isFinished()) {
                 [cursor, keys] = await client.scan(cursor, { count: 10 });
@@ -143,7 +143,7 @@ describe("Scan GlideClusterClient", () => {
             );
 
             let cursor = new ClusterScanCursor();
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             while (!cursor.isFinished()) {
@@ -186,7 +186,7 @@ describe("Scan GlideClusterClient", () => {
                 expect(await client.set(key3, "value")).toEqual("OK");
 
             let cursor = new ClusterScanCursor();
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             while (!cursor.isFinished()) {
@@ -223,8 +223,8 @@ describe("Scan GlideClusterClient", () => {
                 expect(await client.set(key, "value")).toEqual("OK");
 
             let cursor = new ClusterScanCursor();
-            let keysOf1: GlideString[] = [];
-            let keysOf100: GlideString[] = [];
+            let keysOf1: GlideString[];
+            let keysOf100: GlideString[];
             const allKeys: GlideString[] = [];
             let successfulComparedScans = 0;
 
@@ -271,7 +271,7 @@ describe("Scan GlideClusterClient", () => {
             );
 
             let cursor = new ClusterScanCursor();
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             while (!cursor.isFinished()) {
@@ -348,7 +348,7 @@ describe("Scan GlideClusterClient", () => {
             const encodedStreamKeys = streamKeys.map((key) => Buffer.from(key));
 
             let cursor = new ClusterScanCursor();
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             while (!cursor.isFinished()) {
@@ -590,7 +590,7 @@ describe("Scan GlideClient", () => {
             ]);
             let cursor: GlideString = "0";
             const allKeys: GlideString[] = [];
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
 
             do {
                 [cursor, keys] = await client.scan(cursor, { count: 10 });
@@ -660,7 +660,7 @@ describe("Scan GlideClient", () => {
             );
 
             let cursor: GlideString = "0";
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             do {
@@ -703,7 +703,7 @@ describe("Scan GlideClient", () => {
                 expect(await client.set(key3, "value")).toEqual("OK");
 
             let cursor: GlideString = "0";
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             do {
@@ -740,8 +740,8 @@ describe("Scan GlideClient", () => {
                 expect(await client.set(key, "value")).toEqual("OK");
 
             let cursor: GlideString = "0";
-            let keysOf1: GlideString[] = [];
-            let keysOf100: GlideString[] = [];
+            let keysOf1: GlideString[];
+            let keysOf100: GlideString[];
             const allKeys: GlideString[] = [];
             let successfulComparedScans = 0;
 
@@ -788,7 +788,7 @@ describe("Scan GlideClient", () => {
             );
 
             let cursor: GlideString = "0";
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeysEncoded: GlideString[] = [];
 
             do {
@@ -865,7 +865,7 @@ describe("Scan GlideClient", () => {
             const encodedStreamKeys = streamKeys.map((key) => Buffer.from(key));
 
             let cursor: GlideString = "0";
-            let keys: GlideString[] = [];
+            let keys: GlideString[];
             const allKeys: GlideString[] = [];
 
             do {

--- a/node/tests/SharedTests.ts
+++ b/node/tests/SharedTests.ts
@@ -4530,7 +4530,7 @@ export function runBaseTests(config: {
                 );
 
                 let resultCursor = "0";
-                let secondResultValues: GlideString[] = [];
+                let secondResultValues: GlideString[];
 
                 let isFirstLoop = true;
 

--- a/node/tests/TestUtilities.ts
+++ b/node/tests/TestUtilities.ts
@@ -370,6 +370,7 @@ export const parseEndpoints = (endpointsStr: string): [string, number][] => {
     } catch (error) {
         throw new Error(
             "Invalid endpoints format: " + (error as Error).message,
+            { cause: error },
         );
     }
 };
@@ -2543,7 +2544,7 @@ export async function getServerVersion(
     clusterMode = false,
     tlsConfig?: TestTLSConfig,
 ): Promise<string> {
-    let info = "";
+    let info: string;
 
     if (clusterMode) {
         const glideClusterClient = await GlideClusterClient.createClient({

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -683,22 +683,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1039,7 +1026,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "bytes",
- "dashmap 5.5.3",
+ "dashmap",
  "directories",
  "futures",
  "futures-intrusive",
@@ -2242,7 +2229,7 @@ dependencies = [
  "bytes",
  "combine",
  "crc16",
- "dashmap 6.1.0",
+ "dashmap",
  "dispose",
  "futures",
  "futures-util",

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
### Summary

Standardize all Rust dependency graphs on `dashmap` 6.2.1.

This removes previously mixed DashMap resolutions from independent lockfiles,
including the Node Rust client’s direct DashMap 5.x dependency. All affected
Cargo roots now resolve a single `dashmap` 6.2.1 package record.

### Issue link

This Pull Request is linked to issue:
[[Task] Clean up Rust DashMap dependencies](https://github.com/valkey-io/valkey-glide/issues/6913)
Closes: #6913

### Features / Behaviour Changes

No user-facing API or behavior changes are intended.

The Node Rust client, `glide-core`, vendored Redis, Java JNI, FFI, Python async
bindings, Rust benchmarks, and Miri fixtures now resolve to `dashmap` 6.2.1
rather than a mix of 5.5.3, 6.1.0, and 6.2.1.

### Implementation

- Pinned direct DashMap dependencies to `~6.2.1` in:
  - `glide-core/Cargo.toml`
  - `glide-core/redis-rs/redis/Cargo.toml`
  - `ffi/Cargo.toml`
  - `node/rust-client/Cargo.toml`
  - `java/Cargo.toml`
- Regenerated the affected independent `Cargo.lock` files, including Python
  async, Rust benchmarks, FFI, Node, Java, and Miri fixture roots.
- Updated the Node Rust client from DashMap 5.x to 6.2.1. Its existing use of
  `new`, `get`, `get_mut`, `insert`, `remove`, `iter`, and `retain` remains
  source-compatible; no Rust source changes were required.

Cargo now removes obsolete version-qualified references such as
`"dashmap 5.5.3"` and `"dashmap 6.1.0"` where a package root has only one
DashMap resolution, replacing them with an unqualified `"dashmap"` reference.

### Limitations

No known functional limitations.

Miri itself was not run locally because the repository-pinned nightly toolchain
could not install a required component. The Miri fixture dependency graph was
resolved and compiled successfully with stable Cargo.

### Testing

Completed:

- `cargo check --locked` for:
  - `glide-core`
  - `ffi`
  - `node/rust-client`
  - `java`
  - `python/glide-async`
  - `benchmarks/rust`
- `cargo check --locked --features cluster-async` for
  `glide-core/redis-rs/redis`.
- `cargo +stable check --locked` for `ffi/miri-tests`.
- Confirmed each relevant `Cargo.lock` resolves only `dashmap 6.2.1`.
- Confirmed the Node Rust client no longer resolves duplicate DashMap major
  versions.
- `git diff --check`.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
