### PR TITLE
Node: fix flaky OpenTelemetry cluster setup and teardown

### DIFF
--- a/node/tests/OpenTelemetry.test.ts
+++ b/node/tests/OpenTelemetry.test.ts
@@ -86,6 +86,51 @@ const INIT_PARENT_CTX: GlideSpanContext = {
     traceFlags: 1,
 };
 
+/**
+ * Creates a Valkey cluster, retrying transient startup failures.
+ *
+ * `utils/cluster_manager.py` occasionally fails to bring up a fresh cluster in
+ * CI (e.g. "Failed to send CLUSTER MEET command", preceded by a port-in-use
+ * check timeout). Each attempt spawns a fresh cluster_manager.py invocation
+ * with newly allocated random ports, so a retry is a clean, independent attempt
+ * rather than a wait on the same failing resource. No artificial backoff is
+ * used.
+ *
+ * @param clusterMode - Whether to create a cluster-mode deployment.
+ * @param shardCount - Number of shards (primaries).
+ * @param replicaCount - Number of replicas per shard.
+ * @param attempts - Maximum number of creation attempts.
+ * @returns The created ValkeyCluster.
+ * @throws The last error encountered if every attempt fails.
+ */
+async function createClusterWithRetry(
+    clusterMode: boolean,
+    shardCount: number,
+    replicaCount: number,
+    attempts = 3,
+): Promise<ValkeyCluster> {
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+        try {
+            return await ValkeyCluster.createCluster(
+                clusterMode,
+                shardCount,
+                replicaCount,
+                getServerVersion,
+            );
+        } catch (error: unknown) {
+            lastError = error;
+            console.warn(
+                `Cluster creation attempt ${attempt}/${attempts} failed: ` +
+                    `${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    throw lastError;
+}
+
 async function wrongOpenTelemetryConfig() {
     // wrong traces endpoint
     let openTelemetryConfig: OpenTelemetryConfig = {
@@ -182,7 +227,7 @@ describe("OpenTelemetry GlideClusterClient", () => {
                   getServerVersion,
               )
             : // setting replicaCount to 1 to facilitate tests routed to replicas
-              await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
+              await createClusterWithRetry(true, 3, 1);
 
         // check wrong open telemetry config before initilise it
         await wrongOpenTelemetryConfig();
@@ -223,10 +268,12 @@ describe("OpenTelemetry GlideClusterClient", () => {
     });
 
     afterAll(async () => {
-        if (testsFailed === 0) {
-            await cluster.close();
-        } else {
-            await cluster.close(true);
+        if (cluster) {
+            if (testsFailed === 0) {
+                await cluster.close();
+            } else {
+                await cluster.close(true);
+            }
         }
     });
 
@@ -555,7 +602,7 @@ describe("OpenTelemetry GlideClient", () => {
                   parseEndpoints(standaloneAddresses),
                   getServerVersion,
               )
-            : await ValkeyCluster.createCluster(false, 1, 1, getServerVersion);
+            : await createClusterWithRetry(false, 1, 1);
     }, 20000);
 
     afterEach(async () => {
@@ -564,14 +611,16 @@ describe("OpenTelemetry GlideClient", () => {
             fs.unlinkSync(VALID_ENDPOINT_TRACES);
         }
 
-        await flushAndCloseClient(false, cluster.getAddresses(), client);
+        await flushAndCloseClient(false, cluster?.getAddresses(), client);
     });
 
     afterAll(async () => {
-        if (testsFailed === 0) {
-            await cluster.close();
-        } else {
-            await cluster.close(true);
+        if (cluster) {
+            if (testsFailed === 0) {
+                await cluster.close();
+            } else {
+                await cluster.close(true);
+            }
         }
     });
 
@@ -950,7 +999,7 @@ describe("OpenTelemetry parent span context propagation", () => {
                   parseEndpoints(clusterAddresses),
                   getServerVersion,
               )
-            : await ValkeyCluster.createCluster(true, 3, 1, getServerVersion);
+            : await createClusterWithRetry(true, 3, 1);
     }, 40000);
 
     afterEach(async () => {
@@ -964,7 +1013,9 @@ describe("OpenTelemetry parent span context propagation", () => {
     });
 
     afterAll(async () => {
-        await cluster.close();
+        if (cluster) {
+            await cluster.close();
+        }
     });
 
     it(


### PR DESCRIPTION
### Summary

Fixes the flaky `node/tests/OpenTelemetry.test.ts` suite. In CI, `utils/cluster_manager.py` transiently fails to bring up a fresh cluster ("Failed to send CLUSTER MEET command", preceded by a port-in-use check timeout), which rejects the suite's `beforeAll`. The unguarded `afterAll` then called `cluster.close()` on an undefined `cluster`, throwing `TypeError: Cannot read properties of undefined (reading 'close')` and masking the real setup failure. Two propagation tests additionally failed downstream with `ENOENT: /tmp/spans.json`.

### Issue link

This Pull Request is linked to issue: [\[Node\]\[Flaky Test\] OpenTelemetry.test.ts - cluster_manager CLUSTER MEET failure in container tests](https://github.com/valkey-io/valkey-glide/issues/6910)
Closes #6910

### Features / Behaviour Changes

No behaviour changes. Test-only reliability improvement.

### Implementation

- Added a module-scoped `createClusterWithRetry()` helper that retries `ValkeyCluster.createCluster` up to 3 times. Each attempt spawns a fresh `cluster_manager.py` invocation with newly allocated random ports, so a retry is a clean, independent attempt — no artificial sleep/backoff is used.
- Used the helper in all three suites' `beforeAll` (cluster 3×1, standalone 1×1, propagation 3×1).
- Guarded every `afterAll` with `if (cluster) { ... }` so a failed setup no longer throws on an undefined `cluster`. Original `close()` semantics are preserved.
- Added optional chaining (`cluster?.getAddresses()`) in the standalone `afterEach` for consistency with the other suites.

### Limitations

If cluster creation genuinely fails 3 times in a row, the suite still fails — but now with the real underlying error instead of the masking `TypeError`.

### Testing

The affected suite was run 100× locally against a freshly started Valkey (via `utils/cluster_manager.py`) and passed all 100 runs. TypeScript type-check (`tsc --noEmit`) passes.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated. — N/A: test-only change, no CHANGELOG entry required.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`). — Deferred to CI, which is the lint gate.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] Make sure to update the documentation in the valkey-glide-docs repository if necessary — N/A.