### PR TITLE
chore(deps): bump chacha20 to 0.10.2 to clear yanked-crate advisory

### DIFF
--- a/benchmarks/rust/Cargo.lock
+++ b/benchmarks/rust/Cargo.lock
@@ -581,9 +581,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/ffi/Cargo.lock
+++ b/ffi/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/glide-core/Cargo.lock
+++ b/glide-core/Cargo.lock
@@ -585,9 +585,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -526,9 +526,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/node/rust-client/Cargo.lock
+++ b/node/rust-client/Cargo.lock
@@ -547,9 +547,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/python/glide-async/Cargo.lock
+++ b/python/glide-async/Cargo.lock
@@ -520,9 +520,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Bumps `chacha20` off the yanked `0.10.0` release to `0.10.2` (a semver-compatible patch) across the `Cargo.lock` files that cargo-deny scans in CI.
The `chacha20 0.10.0` release was yanked from crates.io, which fails the cargo-deny yanked-crate advisory check.
`main` currently carries this pre-existing lockfile drift.
The same fix was already applied to `release-2.5` in #6923; this applies it to `main`.

`chacha20` is pulled in transitively via `rand 0.10.1 <- uuid 1.23.1`.
This is a lockfile-only change with minimal churn: only the `chacha20` version and checksum lines change, no source or `Cargo.toml` changes.

### Issue link

N/A. This is a dependency lockfile bump to clear a cargo-deny yanked-crate advisory (same fix as #6923 on `release-2.5`).

### Features / Behaviour Changes

None. No runtime or API behaviour changes.

### Implementation

Updated `chacha20` from `0.10.0` to `0.10.2` in the six CI-scanned lockfiles:

- `python/glide-async/Cargo.lock`
- `ffi/Cargo.lock`
- `glide-core/Cargo.lock`
- `benchmarks/rust/Cargo.lock`
- `java/Cargo.lock`
- `node/rust-client/Cargo.lock`

Only the `chacha20` `version` and `checksum` lines change in each file. No other dependency resolution drifts.

### Limitations

None.

### Testing

Lockfile-only change; CI is the gate.
The cargo-deny advisories check should now pass since `chacha20 0.10.2` is not yanked.
The same bump was validated on `release-2.5` in #6923.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
