### PR TITLE
test(python): clear stale WATCH in pooled-client teardown (backport #6678)

### DIFF
--- a/python/tests/async_tests/conftest.py
+++ b/python/tests/async_tests/conftest.py
@@ -167,6 +167,7 @@ async def _async_pool_teardown(client, cluster_mode: bool, cache_key: tuple) -> 
         batch.custom_command(["CONFIG", "SET", "timeout", "0"])
         if not cluster_mode:
             batch.custom_command(["SELECT", "0"])
+        batch.custom_command(["UNWATCH"])
         batch.custom_command(["FLUSHALL", "ASYNC"])
         await client.exec(batch, raise_on_error=True)
     except Exception:

--- a/python/tests/sync_tests/conftest.py
+++ b/python/tests/sync_tests/conftest.py
@@ -100,6 +100,7 @@ def _pool_teardown(client, cluster_mode: bool, cache_key: tuple) -> None:
         batch.custom_command(["CONFIG", "SET", "timeout", "0"])
         if not cluster_mode:
             batch.custom_command(["SELECT", "0"])
+        batch.custom_command(["UNWATCH"])
         batch.custom_command(["FLUSHALL", "ASYNC"])
         client.exec(batch, raise_on_error=True)
     except Exception:


### PR DESCRIPTION
### Summary

Adds `UNWATCH` to the async and sync pooled-client teardown so a leftover `WATCH` on the shared pooled client cannot abort the next atomic cluster batch (which otherwise returns nil and fails `test_cluster_move_transaction` / `test_cluster_batch` on RESP3 cluster). This is the teardown stabilization from #6678, applied to release-2.5.

### Issue link

This Pull Request is linked to issue: backport of the teardown stabilization from #6678.

### Features / Behaviour Changes

Test-harness stabilization only. No product or public API behaviour changes.

### Implementation

Inserts `batch.custom_command(["UNWATCH"])` immediately before the `FLUSHALL ASYNC` step in the pooled-client teardown, in both `python/tests/async_tests/conftest.py` and `python/tests/sync_tests/conftest.py`. This clears any `WATCH` state left on the shared pooled test client at the end of a test, so the next atomic cluster batch executed over the pooled client is not silently aborted.

Companion note: the full fix on main also relies on the #6605 test-harness backport (client eviction); that is being backported separately. This PR is the missing `UNWATCH` teardown line on its own.

### Limitations

None.

### Testing

Diff is limited to the two additive teardown lines. Python linters (black, isort, flake8) were run against both changed files and pass. Functional confirmation of `test_cluster_move_transaction` / `test_cluster_batch` on RESP3 cluster comes from release-2.5 CI on this PR; a standalone local green is not guaranteed because these atomic-batch tests also depend on the companion #6605 harness that is not yet on release-2.5.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] CHANGELOG.md and documentation files are updated.
-   [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
-   [x] Destination branch is correct - main or release
-   [x] Create merge commit if merging release branch into main, squash otherwise.
-   [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
