### PR TITLE
fix(node): fix napi v3 CLI renames in prepublishOnly script

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -81,7 +81,7 @@
         "staged": "lint-staged",
         "prereq": "npm ci",
         "artifacts": "napi artifacts",
-        "prepublishOnly": "cd ../.. && napi prepublish --config npm/glide/package.json -t npm --skip-gh-release",
+        "prepublishOnly": "cd ../.. && napi pre-publish --config-path npm/glide/package.json -t npm --no-gh-release",
         "docs": "npm run build && ./docs/build-docs"
     },
     "devDependencies": {


### PR DESCRIPTION
### Summary

Fix napi-rs v3 CLI flag renames in the `prepublishOnly` script that would cause all npm publish steps to fail.

### Issue link

This Pull Request is linked to issue: N/A (discovered during v2.5.2-rc3 release publish — napi-rs v3 CLI flag renames)

### Features / Behaviour Changes

No user-facing behaviour changes. Build system fix only.

### Implementation

napi-rs v3 renamed several CLI flags used in the `prepublishOnly` script in `node/package.json`:

| v2 | v3 | Notes |
|---|---|---|
| `napi prepublish` | `napi pre-publish` | subcommand renamed (old name still works as alias but `--config` flag is broken) |
| `--config <path>` | `--config-path <path>` | flag renamed |
| `--skip-gh-release` | `--no-gh-release` | flag replaced by negation of `--gh-release` boolean |

**Before:**
```
napi prepublish --config npm/glide/package.json -t npm --skip-gh-release
```

**After:**
```
napi pre-publish --config-path npm/glide/package.json -t npm --no-gh-release
```

This bug affects both `release-2.5` and `main` branches — it would cause the npm publish step to fail on any branch that has been upgraded to `@napi-rs/cli` v3 (done for `release-2.5` in PR #6908). A companion PR should be opened against `main` with the same single-line change.

### Limitations

None.

### Testing

- Verified against the napi-rs v3 CLI source (`cli/src/def/pre-publish.ts`) and official docs
- The fix was confirmed by the error output from the v2.5.2-rc3 release run which showed the exact flag names accepted by v3

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - `release-2.5`
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
