### PR TITLE
fix(node): use --package-json-path instead of --config-path in prepublishOnly

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -81,7 +81,7 @@
         "staged": "lint-staged",
         "prereq": "npm ci",
         "artifacts": "napi artifacts",
-        "prepublishOnly": "cd ../.. && napi pre-publish --config-path npm/glide/package.json -t npm --no-gh-release",
+        "prepublishOnly": "cd ../.. && napi pre-publish --package-json-path npm/glide/package.json -t npm --no-gh-release",
         "docs": "npm run build && ./docs/build-docs"
     },
     "devDependencies": {


### PR DESCRIPTION
### Summary

Fix the `prepublishOnly` script to use `--package-json-path` instead of `--config-path` when calling `napi pre-publish`, preventing a "stale main entry" error during npm publish.

### Issue link

This Pull Request is linked to issue: N/A (publish failure discovered during v2.5.2-rc3 release)

### Features / Behaviour Changes

No user-facing behaviour changes. Build system fix only.

### Implementation

napi v3 `pre-publish` has two distinct flags for specifying a configuration file:

- `--config-path`: parses the file as a raw `UserNapiConfig` JSON object (just the `napi{}` block). The top-level `"name"` field of the file is interpreted as `binaryName`, so passing `node/npm/glide/package.json` (which has `"name": "@valkey/valkey-glide"`) causes napi to derive the expected `.node` filename as `@valkey/valkey-glide.darwin-x64.node`.
- `--package-json-path`: parses the file as a full `package.json` and correctly reads `binaryName` from the `napi.binaryName` field (`"valkey-glide"`), producing the correct expected filename `valkey-glide.darwin-x64.node`.

The mismatch between the computed expected filename and the actual `main` field in `node/npm/darwin-x64/package.json` caused the publish to fail with:

```
Internal Error: Release package @valkey/valkey-glide-darwin-x64 has stale main entry
valkey-glide.darwin-x64.node; expected @valkey/valkey-glide.darwin-x64.node
```

**Change:**
```diff
- "prepublishOnly": "cd ../.. && napi pre-publish --config-path npm/glide/package.json -t npm --no-gh-release"
+ "prepublishOnly": "cd ../.. && napi pre-publish --package-json-path npm/glide/package.json -t npm --no-gh-release"
```

This bug also exists on `main` — a companion PR should be opened there with the same single-line change.

### Limitations

None.

### Testing

- Verified against napi-rs v3.8.6 source: `--package-json-path` reads `napi.binaryName` from the `napi{}` block; `--config-path` reads the top-level file keys as config properties.
- The fix was confirmed by the error output from the v2.5.2-rc3 release run (GitHub Actions run 33191414909).

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - `release-2.5`
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
