### PR TITLE
docs(node): Improve basic client examples

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -88,8 +88,9 @@ const client = await GlideClient.createClient({
     requestTimeout: 500,
     clientName: "test_standalone_client",
 });
-// The empty array signifies that there are no additional arguments.
+
 try {
+    // Pass the command and its arguments as an array.
     const pong = await client.customCommand(["PING"]);
     Logger.log("info", "app", `PING response: ${pong}`);
 
@@ -127,8 +128,9 @@ const client = await GlideClusterClient.createClient({
     requestTimeout: 500,
     clientName: "test_cluster_client",
 });
-// The empty array signifies that there are no additional arguments.
+
 try {
+    // Pass the command and its arguments as an array.
     const pong = await client.customCommand(["PING"], {
         route: "randomNode",
     });

--- a/node/README.md
+++ b/node/README.md
@@ -68,60 +68,80 @@ npm i @valkey/valkey-glide
 #### Standalone Mode:
 
 ```typescript
-import { GlideClient, GlideClusterClient, Logger } from "@valkey/valkey-glide";
-// When Valkey is in standalone mode, add address of the primary node, and any replicas you'd like to be able to read from.
+import { GlideClient, Logger } from "@valkey/valkey-glide";
+
+Logger.setLoggerConfig("info");
+
 const addresses = [
     {
         host: "localhost",
         port: 6379,
     },
 ];
-// Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
+
+// Check `GlideClientConfiguration` for additional options.
 const client = await GlideClient.createClient({
-    addresses: addresses,
-    // if the server uses TLS, you'll need to enable it. Otherwise, the connection attempt will time out silently.
+    addresses,
+    // Enable TLS if required by the server.
     // useTLS: true,
-    // It is recommended to set a timeout for your specific use case
-    requestTimeout: 500, // 500ms timeout
+    // Set a timeout appropriate for your use case.
+    requestTimeout: 500,
     clientName: "test_standalone_client",
 });
 // The empty array signifies that there are no additional arguments.
-const pong = await client.customCommand(["PING"]);
-console.log(pong);
-const set_response = await client.set("foo", "bar");
-console.log(`Set response is = ${set_response}`);
-const get_response = await client.get("foo");
-console.log(`Get response is = ${get_response}`);
+try {
+    const pong = await client.customCommand(["PING"]);
+    Logger.log("info", "app", `PING response: ${pong}`);
+
+    const setResponse = await client.set("foo", "bar");
+    Logger.log("info", "app", `Set response is: ${setResponse}`);
+
+    const getResponse = await client.get("foo");
+    Logger.log("info", "app", `Get response is: ${getResponse}`);
+} finally {
+    client.close();
+}
 ```
 
 #### Cluster Mode:
 
 ```typescript
-import { GlideClient, GlideClusterClient, Logger } from "@valkey/valkey-glide";
-// When Valkey is in cluster mode, add address of any nodes, and the client will find all nodes in the cluster.
+import { GlideClusterClient, Logger } from "@valkey/valkey-glide";
+
+Logger.setLoggerConfig("info");
+
+// Add the address of any cluster node; the client discovers the remaining nodes.
 const addresses = [
     {
         host: "localhost",
         port: 6379,
     },
 ];
-// Check `GlideClientConfiguration/GlideClusterClientConfiguration` for additional options.
+
+// Check `GlideClusterClientConfiguration` for additional options.
 const client = await GlideClusterClient.createClient({
-    addresses: addresses,
-    // if the cluster nodes use TLS, you'll need to enable it. Otherwise the connection attempt will time out silently.
+    addresses,
+    // Enable TLS if required by the cluster nodes.
     // useTLS: true,
-    // It is recommended to set a timeout for your specific use case
-    requestTimeout: 500, // 500ms timeout
+    // Set a timeout appropriate for your use case.
+    requestTimeout: 500,
     clientName: "test_cluster_client",
 });
 // The empty array signifies that there are no additional arguments.
-const pong = await client.customCommand(["PING"], { route: "randomNode" });
-console.log(pong);
-const set_response = await client.set("foo", "bar");
-console.log(`Set response is = ${set_response}`);
-const get_response = await client.get("foo");
-console.log(`Get response is = ${get_response}`);
-client.close();
+try {
+    const pong = await client.customCommand(["PING"], {
+        route: "randomNode",
+    });
+    Logger.log("info", "app", `PING response: ${pong}`);
+
+    const setResponse = await client.set("foo", "bar");
+    Logger.log("info", "app", `Set response is: ${setResponse}`);
+
+    const getResponse = await client.get("foo");
+    Logger.log("info", "app", `Get response is: ${getResponse}`);
+} finally {
+    client.close();
+}
 ```
 
 ### Supported platforms


### PR DESCRIPTION
A quick update to the node README.md examples to use idiomatic GLIDE patterns.

- use the GLIDE logger for command output
- remove unused imports
- follow TypeScript naming and object shorthand conventions
- cleanup configuration comments and close client in finally block

### Testing
- Tested locally in standalone and cluster modes with each sample.