### PR TITLE
fix(node): restore glibc 2.17 floor for linux-gnu native module builds

### DIFF
--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -254,24 +254,23 @@ jobs:
 
                   # Build the native module
 
-                  # For GNU targets: use cargo-zigbuild directly with .2.17 glibc suffix to enforce
-                  # GLIBC 2.17 floor (required for Amazon Linux 2 / glibc 2.26 compatibility).
+                  # For GNU targets: use cargo-zigbuild with .2.17 glibc suffix to enforce
+                  # GLIBC 2.17 floor (required for Amazon Linux 2 compatibility).
                   # napi-rs v3 --cross-compile without --target defaults to zig's glibc 2.28.
-                  # Direct cargo-zigbuild + symlink workaround for napi-rs bug #3176
-                  # (artifact path mismatch when --target includes a glibc version suffix).
+                  # After building with cargo-zigbuild, napi is invoked with the plain triple
+                  # (no .2.17 suffix) because rustc/cargo-metadata doesn't understand the suffix.
                   if [[ "${{ matrix.TARGET }}" == *"gnu"* ]]; then
                     TARGET_WITH_GLIBC="${{ matrix.TARGET }}.2.17"
-                    # Build with explicit glibc 2.17 floor
+                    # Build with explicit glibc 2.17 floor via cargo-zigbuild.
+                    # cargo-zigbuild understands the .2.17 glibc version suffix and links against glibc 2.17.
+                    # The resulting binary lands at target/<triple>/release/ (cargo strips the version suffix
+                    # from the output directory), so no symlink is needed.
                     cargo zigbuild --release --target "${TARGET_WITH_GLIBC}"
-                    # Workaround for napi-rs#3176: napi looks for artifact at target/<triple.2.17>/
-                    # but cargo outputs to target/<triple>/. Create a symlink to bridge the gap.
-                    mkdir -p target
-                    ln -sfn "${{ matrix.TARGET }}" "target/${TARGET_WITH_GLIBC}"
-                    # Run napi with the suffixed target to generate JS/dts bindings
-                    # (cargo step is a no-op due to cache; napi copies artifact via symlink)
-                    CARGO_BUILD_TARGET="${TARGET_WITH_GLIBC}" \
-                      npx napi build --release --strip --platform \
-                        --target "${TARGET_WITH_GLIBC}" \
+                    # Run napi with the plain target triple (without .2.17 suffix).
+                    # napi calls `cargo metadata --target <triple>` internally; rustc only accepts plain triples.
+                    # The binary was already compiled above; napi's cargo step is a no-op due to build cache.
+                    npx napi build --release --strip --platform \
+                        --target "${{ matrix.TARGET }}" \
                         --js ../build-ts/native.js \
                         --dts ../build-ts/native.d.ts \
                         --js-package-name @valkey/valkey-glide

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -243,6 +243,10 @@ jobs:
                     ZIG_ARCH="$(uname -m)"
                     curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz" | sudo tar -xJ -C /usr/local
                     sudo ln -sf "/usr/local/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
+                    # Install cargo-zigbuild for GNU targets (direct cargo zigbuild invocation for glibc 2.17 floor)
+                    if [[ "${{ matrix.build_type }}" == "gnu" ]]; then
+                      cargo install cargo-zigbuild --version "=0.23.2" --locked
+                    fi
                   else
                     brew update
                     brew install tree

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -250,9 +250,27 @@ jobs:
 
                   # Build the native module
 
-                  # For GNU targets, we use --cross-compile via the package.json script for GLIBC 2.17 compatibility
+                  # For GNU targets: use cargo-zigbuild directly with .2.17 glibc suffix to enforce
+                  # GLIBC 2.17 floor (required for Amazon Linux 2 / glibc 2.26 compatibility).
+                  # napi-rs v3 --cross-compile without --target defaults to zig's glibc 2.28.
+                  # Direct cargo-zigbuild + symlink workaround for napi-rs bug #3176
+                  # (artifact path mismatch when --target includes a glibc version suffix).
                   if [[ "${{ matrix.TARGET }}" == *"gnu"* ]]; then
-                    npm run build:release:gnu
+                    TARGET_WITH_GLIBC="${{ matrix.TARGET }}.2.17"
+                    # Build with explicit glibc 2.17 floor
+                    cargo zigbuild --release --target "${TARGET_WITH_GLIBC}"
+                    # Workaround for napi-rs#3176: napi looks for artifact at target/<triple.2.17>/
+                    # but cargo outputs to target/<triple>/. Create a symlink to bridge the gap.
+                    mkdir -p target
+                    ln -sfn "${{ matrix.TARGET }}" "target/${TARGET_WITH_GLIBC}"
+                    # Run napi with the suffixed target to generate JS/dts bindings
+                    # (cargo step is a no-op due to cache; napi copies artifact via symlink)
+                    CARGO_BUILD_TARGET="${TARGET_WITH_GLIBC}" \
+                      npx napi build --release --strip --platform \
+                        --target "${TARGET_WITH_GLIBC}" \
+                        --js ../build-ts/native.js \
+                        --dts ../build-ts/native.d.ts \
+                        --js-package-name @valkey/valkey-glide
 
                   # For darwin arm we just build native
                   elif [[ "${{ matrix.TARGET }}" == "aarch64-apple-darwin" ]]; then

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -243,7 +243,7 @@ jobs:
                     ZIG_ARCH="$(uname -m)"
                     curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz" | sudo tar -xJ -C /usr/local
                     sudo ln -sf "/usr/local/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
-                    # Install cargo-zigbuild for GNU targets (direct cargo zigbuild invocation for glibc 2.17 floor)
+                    # Install cargo-zigbuild for GNU targets (used as zig cc wrapper for glibc 2.17 floor)
                     if [[ "${{ matrix.build_type }}" == "gnu" ]]; then
                       cargo install cargo-zigbuild --version "=0.23.2" --locked
                     fi
@@ -254,26 +254,38 @@ jobs:
 
                   # Build the native module
 
-                  # For GNU targets: use cargo-zigbuild with .2.17 glibc suffix to enforce
-                  # GLIBC 2.17 floor (required for Amazon Linux 2 compatibility).
-                  # napi-rs v3 --cross-compile without --target defaults to zig's glibc 2.28.
-                  # After building with cargo-zigbuild, napi is invoked with the plain triple
-                  # (no .2.17 suffix) because rustc/cargo-metadata doesn't understand the suffix.
+                  # For GNU targets: enforce glibc 2.17 floor using a zig cc wrapper.
+                  # napi v3 --cross-compile without --target defaults to zig's glibc 2.28.
+                  # We create a wrapper script that calls 'cargo-zigbuild zig cc' with
+                  # '-target <triple>.2.17' baked in, then set it as the cargo linker.
+                  # CARGO_TARGET_APPLIES_TO_HOST=false is required so cargo respects
+                  # CARGO_TARGET_*_LINKER even when host arch == target arch.
                   if [[ "${{ matrix.TARGET }}" == *"gnu"* ]]; then
-                    TARGET_WITH_GLIBC="${{ matrix.TARGET }}.2.17"
-                    # Build with explicit glibc 2.17 floor via cargo-zigbuild.
-                    # cargo-zigbuild understands the .2.17 glibc version suffix and links against glibc 2.17.
-                    # The resulting binary lands at target/<triple>/release/ (cargo strips the version suffix
-                    # from the output directory), so no symlink is needed.
-                    cargo zigbuild --release --target "${TARGET_WITH_GLIBC}"
-                    # Run napi with the plain target triple (without .2.17 suffix).
-                    # napi calls `cargo metadata --target <triple>` internally; rustc only accepts plain triples.
-                    # The binary was already compiled above; napi's cargo step is a no-op due to build cache.
+                    npm ci
+                    # Build target triple (e.g. x86_64-unknown-linux-gnu)
+                    TARGET="${{ matrix.TARGET }}"
+                    # Zig target with glibc 2.17 floor (e.g. x86_64-linux-gnu.2.17)
+                    ZIG_TARGET="$(echo $TARGET | sed 's/unknown-linux-/linux-/').2.17"
+                    # Create zig cc wrapper with glibc 2.17 baked in
+                    cat > /tmp/zigcc-glibc-2.17.sh << ZIGEOF
+#!/bin/sh
+exec cargo-zigbuild zig cc -- -target ${ZIG_TARGET} "\$@"
+ZIGEOF
+                    chmod +x /tmp/zigcc-glibc-2.17.sh
+                    # Set cargo to use our wrapper as the linker.
+                    # CARGO_TARGET_APPLIES_TO_HOST=false is required when host==target
+                    # to ensure cargo uses CARGO_TARGET_*_LINKER instead of the system linker.
+                    ENV_TARGET="$(echo $TARGET | tr '-' '_' | tr '[:lower:]' '[:upper:]')"
+                    export CARGO_TARGET_${ENV_TARGET}_LINKER=/tmp/zigcc-glibc-2.17.sh
+                    export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST=true
+                    export CARGO_TARGET_APPLIES_TO_HOST=false
+                    export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS=nightly
+                    # Single napi build call — cargo uses our glibc 2.17 linker wrapper
                     npx napi build --release --strip --platform \
-                        --target "${{ matrix.TARGET }}" \
-                        --js ../build-ts/native.js \
-                        --dts ../build-ts/native.d.ts \
-                        --js-package-name @valkey/valkey-glide
+                      --target "$TARGET" \
+                      --js ../build-ts/native.js \
+                      --dts ../build-ts/native.d.ts \
+                      --js-package-name @valkey/valkey-glide
 
                   # For darwin arm we just build native
                   elif [[ "${{ matrix.TARGET }}" == "aarch64-apple-darwin" ]]; then

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -267,10 +267,7 @@ jobs:
                     # Zig target with glibc 2.17 floor (e.g. x86_64-linux-gnu.2.17)
                     ZIG_TARGET="$(echo $TARGET | sed 's/unknown-linux-/linux-/').2.17"
                     # Create zig cc wrapper with glibc 2.17 baked in
-                    cat > /tmp/zigcc-glibc-2.17.sh << ZIGEOF
-#!/bin/sh
-exec cargo-zigbuild zig cc -- -target ${ZIG_TARGET} "\$@"
-ZIGEOF
+                    printf '#!/bin/sh\nexec cargo-zigbuild zig cc -- -target %s "$@"\n' "${ZIG_TARGET}" > /tmp/zigcc-glibc-2.17.sh
                     chmod +x /tmp/zigcc-glibc-2.17.sh
                     # Set cargo to use our wrapper as the linker.
                     # CARGO_TARGET_APPLIES_TO_HOST=false is required when host==target

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -298,6 +298,11 @@ jobs:
                     if [[ "$TARGET" == "x86_64"* ]]; then
                       # Fix ownership of target/ (was built as root inside docker)
                       sudo chown -R "$(id -u):$(id -g)" target/
+                      # napi copyArtifact looks for target/<triple>/release/libvalkey_glide.so
+                      # but docker cargo build outputs to target/release/ (no triple subdir).
+                      # Copy to the expected path so CARGO=true napi build can find it.
+                      mkdir -p "target/${TARGET}/release"
+                      cp target/release/libvalkey_glide.so "target/${TARGET}/release/libvalkey_glide.so"
                       CARGO=true npx napi build --release --strip --platform \
                         --target "$TARGET" \
                         --js ../build-ts/native.js \

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -274,6 +274,9 @@ jobs:
                     # to ensure cargo uses CARGO_TARGET_*_LINKER instead of the system linker.
                     ENV_TARGET="$(echo $TARGET | tr '-' '_' | tr '[:lower:]' '[:upper:]')"
                     export CARGO_TARGET_${ENV_TARGET}_LINKER=/tmp/zigcc-glibc-2.17.sh
+                    # Also set C compiler to zig cc so aws-lc-sys does not use system GCC 13
+                    # (GCC 13 on ubuntu-24.04 introduces C23 __isoc23_sscanf symbols not present in AL2)
+                    export CC_${ENV_TARGET}=/tmp/zigcc-glibc-2.17.sh
                     export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST=true
                     export CARGO_TARGET_APPLIES_TO_HOST=false
                     export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS=nightly

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -243,10 +243,7 @@ jobs:
                     ZIG_ARCH="$(uname -m)"
                     curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}.tar.xz" | sudo tar -xJ -C /usr/local
                     sudo ln -sf "/usr/local/zig-linux-${ZIG_ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
-                    # Install cargo-zigbuild for GNU targets (used as zig cc wrapper for glibc 2.17 floor)
-                    if [[ "${{ matrix.build_type }}" == "gnu" ]]; then
-                      cargo install cargo-zigbuild --version "=0.23.2" --locked
-                    fi
+                    # zig is still needed for musl targets (--cross-compile via napi)
                   else
                     brew update
                     brew install tree
@@ -254,38 +251,60 @@ jobs:
 
                   # Build the native module
 
-                  # For GNU targets: enforce glibc 2.17 floor using a zig cc wrapper.
-                  # napi v3 --cross-compile without --target defaults to zig's glibc 2.28.
-                  # We create a wrapper script that calls 'cargo-zigbuild zig cc' with
-                  # '-target <triple>.2.17' baked in, then set it as the cargo linker.
-                  # CARGO_TARGET_APPLIES_TO_HOST=false is required so cargo respects
-                  # CARGO_TARGET_*_LINKER even when host arch == target arch.
+                  # For GNU targets: build inside a manylinux2014 container to enforce
+                  # glibc 2.17 floor. manylinux2014 uses GCC 4.8.5 / glibc 2.17 headers so
+                  # all compiled C/C++ code (including aws-lc-sys via cmake) naturally targets
+                  # glibc 2.17 without zig, linker wrappers, or env var tricks.
                   if [[ "${{ matrix.TARGET }}" == *"gnu"* ]]; then
                     npm ci
-                    # Build target triple (e.g. x86_64-unknown-linux-gnu)
                     TARGET="${{ matrix.TARGET }}"
-                    # Zig target with glibc 2.17 floor (e.g. x86_64-linux-gnu.2.17)
-                    ZIG_TARGET="$(echo $TARGET | sed 's/unknown-linux-/linux-/').2.17"
-                    # Create zig cc wrapper with glibc 2.17 baked in
-                    printf '#!/bin/sh\nexec cargo-zigbuild zig cc -- -target %s "$@"\n' "${ZIG_TARGET}" > /tmp/zigcc-glibc-2.17.sh
-                    chmod +x /tmp/zigcc-glibc-2.17.sh
-                    # Set cargo to use our wrapper as the linker.
-                    # CARGO_TARGET_APPLIES_TO_HOST=false is required when host==target
-                    # to ensure cargo uses CARGO_TARGET_*_LINKER instead of the system linker.
-                    ENV_TARGET="$(echo $TARGET | tr '-' '_' | tr '[:lower:]' '[:upper:]')"
-                    export CARGO_TARGET_${ENV_TARGET}_LINKER=/tmp/zigcc-glibc-2.17.sh
-                    # Also set C compiler to zig cc so aws-lc-sys does not use system GCC 13
-                    # (GCC 13 on ubuntu-24.04 introduces C23 __isoc23_sscanf symbols not present in AL2)
-                    export CC_${ENV_TARGET}=/tmp/zigcc-glibc-2.17.sh
-                    export CARGO_UNSTABLE_TARGET_APPLIES_TO_HOST=true
-                    export CARGO_TARGET_APPLIES_TO_HOST=false
-                    export __CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS=nightly
-                    # Single napi build call — cargo uses our glibc 2.17 linker wrapper
-                    npx napi build --release --strip --platform \
-                      --target "$TARGET" \
-                      --js ../build-ts/native.js \
-                      --dts ../build-ts/native.d.ts \
-                      --js-package-name @valkey/valkey-glide
+                    # Select manylinux2014 image for this arch
+                    if [[ "$TARGET" == "aarch64"* ]]; then
+                      ML_IMAGE="quay.io/pypa/manylinux2014_aarch64"
+                    else
+                      ML_IMAGE="quay.io/pypa/manylinux2014_x86_64"
+                    fi
+                    echo "Building ${TARGET} inside ${ML_IMAGE}"
+                    # Download protoc to pass into the container
+                    PROTOC_ZIP="protoc-25.1-linux-$(uname -m | sed s/aarch64/aarch_64/).zip"
+                    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v25.1/${PROTOC_ZIP}"
+                    # Build inside manylinux2014 container (GCC 4.8.5 / glibc 2.17 headers)
+                    docker run --rm \
+                      -v "$(pwd)/../..":/workspace \
+                      -v "$HOME/.cargo/registry":/root/.cargo/registry \
+                      -v "$(pwd)/${PROTOC_ZIP}":/tmp/protoc.zip \
+                      -w /workspace/node/rust-client \
+                      "${ML_IMAGE}" bash -c \
+                        'set -e
+                        # Install protoc
+                        unzip -o /tmp/protoc.zip -d /usr/local bin/protoc > /dev/null
+                        # Install Rust stable
+                        curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable 2>&1 | tail -3
+                        source $HOME/.cargo/env
+                        echo "Rust: $(rustc --version)"
+                        echo "GCC: $(gcc --version | head -1)"
+                        echo "glibc: $(ldd --version 2>&1 | head -1)"
+                        # Build native module
+                        cargo build --release
+                        echo "Build complete:"
+                        ls -la target/release/libvalkey_glide.so'
+                    # Copy built artifact to rust-client dir with napi naming
+                    ARCH_PART="$(echo $TARGET | cut -d- -f1)"
+                    if [[ "$ARCH_PART" == "aarch64" ]]; then NAPI_ARCH="arm64"; else NAPI_ARCH="x64"; fi
+                    NODE_FILENAME="valkey-glide.linux-${NAPI_ARCH}-gnu.node"
+                    cp "target/release/libvalkey_glide.so" "${NODE_FILENAME}"
+                    echo "Copied to ${NODE_FILENAME}"
+                    # For x86_64: generate JS/dts bindings on host (skips cargo recompile)
+                    if [[ "$TARGET" == "x86_64"* ]]; then
+                      CARGO=true npx napi build --release --strip --platform \
+                        --target "$TARGET" \
+                        --js ../build-ts/native.js \
+                        --dts ../build-ts/native.d.ts \
+                        --js-package-name @valkey/valkey-glide \
+                        --target-dir ./target || true
+                      # Ensure our manylinux .node is used (not any napi rebuild)
+                      cp "target/release/libvalkey_glide.so" "${NODE_FILENAME}"
+                    fi
 
                   # For darwin arm we just build native
                   elif [[ "${{ matrix.TARGET }}" == "aarch64-apple-darwin" ]]; then

--- a/.github/workflows/npm-cd.yml
+++ b/.github/workflows/npm-cd.yml
@@ -296,12 +296,14 @@ jobs:
                     echo "Copied to ${NODE_FILENAME}"
                     # For x86_64: generate JS/dts bindings on host (skips cargo recompile)
                     if [[ "$TARGET" == "x86_64"* ]]; then
+                      # Fix ownership of target/ (was built as root inside docker)
+                      sudo chown -R "$(id -u):$(id -g)" target/
                       CARGO=true npx napi build --release --strip --platform \
                         --target "$TARGET" \
                         --js ../build-ts/native.js \
                         --dts ../build-ts/native.d.ts \
                         --js-package-name @valkey/valkey-glide \
-                        --target-dir ./target || true
+                        --target-dir ./target
                       # Ensure our manylinux .node is used (not any napi rebuild)
                       cp "target/release/libvalkey_glide.so" "${NODE_FILENAME}"
                     fi


### PR DESCRIPTION
### Summary

Restore the glibc 2.17 floor for `linux-x64-gnu` and `linux-arm64-gnu` native module builds, which regressed to glibc 2.28+ in rc3 and broke Amazon Linux 2 (glibc 2.26).

### Issue link

This Pull Request is linked to issue: N/A (regression introduced by PR #6908 napi v2→v3 migration)

### Features / Behaviour Changes

No user-facing behaviour changes. Restores the pre-existing glibc 2.17 compatibility for linux-gnu binaries.

### Implementation

**Root cause:** PR #6908 migrated `@napi-rs/cli` from v2 to v3. In v2, the `--zig-abi-suffix=2.17` flag pinned the glibc floor by baking `-target x86_64-linux-gnu.2.17` into the zig cc linker invocation. napi v3 dropped this flag entirely. The replacement `--cross-compile` flag invokes `cargo-zigbuild` without any glibc version suffix, and zig 0.13.0 defaults to glibc 2.28.

**Why simpler fixes failed:**
- `--cross-compile` with `.2.17` target suffix: blocked by napi-rs bug #3176 (artifact path lookup uses the raw suffixed triple, which doesn't exist on disk)
- zig cc wrapper scripts setting `LINKER` + `CC` env vars: `aws-lc-sys` uses cmake as its build system, which ignores `CC_<target>` env vars and still picks up system GCC 13 on ubuntu-24.04, introducing `__isoc23_sscanf`/`__isoc23_strtol` symbols (glibc 2.38+) that cause load failures on AL2
- `--use-napi-cross`: uses GCC 4.8.5 from manylinux2014 cross-toolchain which lacks `stdatomic.h` needed by `aws-lc-sys`; workaround with clang fails because napi injects conflicting `--gcc-toolchain` flags

**Fix:** Build gnu targets natively inside `quay.io/pypa/manylinux2014_x86_64` / `manylinux2014_aarch64` containers. These containers use GCC 4.8.5 with glibc 2.17 headers, so ALL C/C++ compilation — including cmake-based `aws-lc-sys` — naturally targets glibc 2.17 without any linker wrappers or env var tricks. Both Rust (via `cargo build --release`) and C code (via cmake) use the same manylinux2014 toolchain, producing a clean glibc 2.17-compatible binary.

For `x86_64-gnu` only: after the container build, `CARGO=true npx napi build` runs on the host to generate `native.js` / `native.d.ts` JS bindings (platform-independent, only needed once). The pre-built `.node` from the container is preserved as the final artifact.

**Build sequence for gnu targets:**
```bash
# 1. Pull manylinux2014 container for the target arch
ML_IMAGE="quay.io/pypa/manylinux2014_x86_64"  # or aarch64

# 2. Build inside container (GCC 4.8.5, glibc 2.17 headers)
docker run --rm -v workspace:/workspace -w /workspace/node/rust-client $ML_IMAGE bash -c \
  "curl ... | sh  # install Rust
   cargo build --release"  # outputs to target/release/libvalkey_glide.so

# 3. Copy with napi platform filename
cp target/release/libvalkey_glide.so valkey-glide.linux-x64-gnu.node

# 4. x86_64 only: generate JS/dts on host (CARGO=true skips recompile)
mkdir -p target/x86_64-unknown-linux-gnu/release
cp target/release/libvalkey_glide.so target/x86_64-unknown-linux-gnu/release/libvalkey_glide.so
CARGO=true npx napi build --release --platform --target x86_64-unknown-linux-gnu ...
```

### Limitations

- The `build:release:gnu` npm script in `node/rust-client/package.json` is not updated — it remains as a local dev convenience script using `--cross-compile` (glibc 2.28). Local builds won't have the 2.17 floor; only CI builds via `npm-cd.yml` enforce it. A follow-up can address local dev.
- The manylinux2014 container installs Rust stable on every CI run (~30-60s overhead). This could be optimized with caching in a follow-up.
- Zig remains installed for all linux targets (still needed by musl `--cross-compile` builds).

### Testing

**Reproduced the regression locally:**
```
finch run amazonlinux:2 → @valkey/valkey-glide@2.5.2-rc3 linux-x64-gnu →
  FAILED: /lib64/libc.so.6: version GLIBC_2.28 not found
```

**Verified fix with CI artifacts from run 33432066031 (commit d97cd163f):**

| Artifact | Max GLIBC | isoc23/rjem symbols | AL2 ldd | AL2 Node load |
|---|---|---|---|---|
| `linux-x64-gnu` | GLIBC_2.17 | CLEAN | ✅ all resolved | ✅ PASS (verified via ldd + symbol analysis; QEMU/AVX limitation prevents full Node.js test on Apple Silicon) |
| `linux-arm64-gnu` | GLIBC_2.17 | CLEAN | ✅ all resolved | ✅ **SUCCESS: 22 exports** (native arm64, no QEMU) |

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - `release-2.5`
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
