### PR TITLE
feat(java): configure OpenTelemetry metrics exporters

### DIFF
--- a/glide-core/src/lib.rs
+++ b/glide-core/src/lib.rs
@@ -25,7 +25,8 @@ pub mod request_type;
 pub mod tls_reload;
 pub use telemetrylib::{
     DEFAULT_FLUSH_SIGNAL_INTERVAL_MS, DEFAULT_TRACE_SAMPLE_PERCENTAGE, GlideOpenTelemetry,
-    GlideOpenTelemetryConfigBuilder, GlideOpenTelemetrySignalsExporter, GlideSpan, Telemetry,
+    GlideOpenTelemetryConfigBuilder, GlideOpenTelemetryMetricsTemporality,
+    GlideOpenTelemetrySignalsExporter, GlideSpan, Telemetry,
 };
 
 #[cfg(feature = "proto")]

--- a/glide-core/telemetry/Cargo.lock
+++ b/glide-core/telemetry/Cargo.lock
@@ -1250,12 +1250,16 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-proto",
  "opentelemetry_sdk",
+ "prost",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "tonic",
  "url",
 ]
 

--- a/glide-core/telemetry/Cargo.toml
+++ b/glide-core/telemetry/Cargo.toml
@@ -17,12 +17,16 @@ url = "2"
 opentelemetry = { version = "0.32", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "metrics", "experimental_metrics_periodicreader_with_async_runtime", "experimental_trace_batch_span_processor_with_async_runtime"] }
 opentelemetry-otlp = { version = "0.32", features = ["http-proto", "http-json", "reqwest-client", "grpc-tonic"] }
+reqwest = { version = "0.13", default-features = false }
+tonic = { version = "0.14", default-features = false }
 once_cell = "1"
 logger_core = { path = "../../logger_core" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread", "time"] }
 tempfile = "3"
+prost = "0.14"
+opentelemetry-proto = { version = "0.32", features = ["gen-tonic-messages", "metrics"] }
 # `testing` exposes `InMemoryMetricExporter`, used by the metrics export tests to
 # drive real SDK aggregation (the 0.32 metric data types are no longer
 # externally constructible).

--- a/glide-core/telemetry/src/metrics_exporter_file.rs
+++ b/glide-core/telemetry/src/metrics_exporter_file.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 pub struct FileMetricExporter {
     is_shutdown: AtomicBool,
     path: PathBuf,
+    temporality: Temporality,
 }
 
 impl FileMetricExporter {
@@ -40,17 +41,25 @@ impl FileMetricExporter {
     /// - The path points to a directory that doesn't exist
     /// - The user doesn't have write permissions for the target location
     pub fn new(path: PathBuf) -> Result<Self, OTelSdkError> {
+        Self::new_with_temporality(path, Temporality::Cumulative)
+    }
+
+    pub fn new_with_temporality(
+        path: PathBuf,
+        temporality: Temporality,
+    ) -> Result<Self, OTelSdkError> {
         // TODO: Check if the file exists and has write permissions - https://github.com/valkey-io/valkey-glide/issues/3720
         Ok(Self {
             is_shutdown: AtomicBool::new(false),
             path,
+            temporality,
         })
     }
 }
 
 impl PushMetricExporter for FileMetricExporter {
     fn temporality(&self) -> Temporality {
-        Temporality::Cumulative
+        self.temporality
     }
 
     async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -5,15 +5,19 @@ use opentelemetry::trace::{
     Span, SpanContext, SpanId, SpanKind, TraceContextExt, TraceFlags, TraceId, TraceState,
 };
 use opentelemetry::{global, trace::Tracer};
-use opentelemetry_otlp::{MetricExporter, Protocol, WithExportConfig};
+use opentelemetry_otlp::{
+    MetricExporter, Protocol, WithExportConfig, WithHttpConfig, WithTonicConfig,
+};
 use opentelemetry_sdk::error::OTelSdkError;
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::{SdkMeterProvider, Temporality};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::trace::{
     BatchConfig, BatchSpanProcessor, SdkTracerProvider, SpanExporter,
     span_processor_with_async_runtime::BatchSpanProcessor as AsyncBatchSpanProcessor,
 };
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -22,6 +26,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 use thiserror::Error;
+use tonic::metadata::{Ascii, MetadataKey, MetadataMap, MetadataValue};
 use url::Url;
 
 const SPAN_WRITE_LOCK_ERR: &str = "Failed to acquire span write lock";
@@ -519,6 +524,27 @@ pub struct GlideOpenTelemetryTracesConfig {
 pub struct GlideOpenTelemetryMetricsConfig {
     /// Specifies how the exporter sends telemetry data to the collector, and holds the endpoint information.
     metrics_exporter: GlideOpenTelemetrySignalsExporter,
+    /// Additional headers sent with every metrics export request.
+    headers: HashMap<String, String>,
+    /// Aggregation temporality used by the metrics exporter.
+    temporality: Option<GlideOpenTelemetryMetricsTemporality>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GlideOpenTelemetryMetricsTemporality {
+    Cumulative,
+    Delta,
+    LowMemory,
+}
+
+impl From<GlideOpenTelemetryMetricsTemporality> for Temporality {
+    fn from(value: GlideOpenTelemetryMetricsTemporality) -> Self {
+        match value {
+            GlideOpenTelemetryMetricsTemporality::Cumulative => Temporality::Cumulative,
+            GlideOpenTelemetryMetricsTemporality::Delta => Temporality::Delta,
+            GlideOpenTelemetryMetricsTemporality::LowMemory => Temporality::LowMemory,
+        }
+    }
 }
 
 /// Builder for configuring OpenTelemetry in GLIDE
@@ -581,6 +607,23 @@ impl GlideOpenTelemetryConfigBuilder {
     pub fn with_metrics_exporter(mut self, exporter: GlideOpenTelemetrySignalsExporter) -> Self {
         self.metrics_config = Some(GlideOpenTelemetryMetricsConfig {
             metrics_exporter: exporter,
+            headers: HashMap::new(),
+            temporality: None,
+        });
+        self
+    }
+
+    /// Configure the metrics exporter, request headers, and aggregation temporality.
+    pub fn with_metrics_exporter_config(
+        mut self,
+        exporter: GlideOpenTelemetrySignalsExporter,
+        headers: HashMap<String, String>,
+        temporality: Option<GlideOpenTelemetryMetricsTemporality>,
+    ) -> Self {
+        self.metrics_config = Some(GlideOpenTelemetryMetricsConfig {
+            metrics_exporter: exporter,
+            headers,
+            temporality,
         });
         self
     }
@@ -643,6 +686,54 @@ static OTEL: OnceCell<RwLock<GlideOpenTelemetry>> = OnceCell::new();
 
 /// Our interface to OpenTelemetry
 impl GlideOpenTelemetry {
+    fn http_client_from_headers(
+        headers: &HashMap<String, String>,
+    ) -> Result<reqwest::Client, GlideOTELError> {
+        let mut default_headers = HeaderMap::new();
+        for (key, value) in headers {
+            let header_name = HeaderName::from_bytes(key.as_bytes()).map_err(|error| {
+                GlideOTELError::Other(format!(
+                    "Invalid OpenTelemetry metrics header name '{key}': {error}"
+                ))
+            })?;
+            let header_value = HeaderValue::from_str(value).map_err(|error| {
+                GlideOTELError::Other(format!(
+                    "Invalid OpenTelemetry metrics header value for '{key}': {error}"
+                ))
+            })?;
+            default_headers.insert(header_name, header_value);
+        }
+        reqwest::Client::builder()
+            .default_headers(default_headers)
+            .build()
+            .map_err(|error| {
+                GlideOTELError::Other(format!(
+                    "Failed to build OpenTelemetry metrics HTTP client: {error}"
+                ))
+            })
+    }
+
+    fn metadata_from_headers(
+        headers: &HashMap<String, String>,
+    ) -> Result<MetadataMap, GlideOTELError> {
+        let mut metadata = MetadataMap::new();
+        for (key, value) in headers {
+            let metadata_key: MetadataKey<Ascii> =
+                key.to_ascii_lowercase().parse().map_err(|error| {
+                    GlideOTELError::Other(format!(
+                        "Invalid OpenTelemetry metrics header name '{key}': {error}"
+                    ))
+                })?;
+            let metadata_value: MetadataValue<Ascii> = value.parse().map_err(|error| {
+                GlideOTELError::Other(format!(
+                    "Invalid OpenTelemetry metrics header value for '{key}': {error}"
+                ))
+            })?;
+            metadata.insert(metadata_key, metadata_value);
+        }
+        Ok(metadata)
+    }
+
     /// Validate if a span pointer is valid
     ///
     /// # Arguments
@@ -753,6 +844,8 @@ impl GlideOpenTelemetry {
                 Self::initialise_metrics_exporter(
                     config.flush_interval_ms,
                     &metrics_config.metrics_exporter,
+                    &metrics_config.headers,
+                    metrics_config.temporality,
                 )?;
                 Self::init_metrics()?;
             }
@@ -882,14 +975,21 @@ impl GlideOpenTelemetry {
     fn initialise_metrics_exporter(
         flush_interval_ms: Duration,
         metrics_exporter: &GlideOpenTelemetrySignalsExporter,
+        headers: &HashMap<String, String>,
+        temporality: Option<GlideOpenTelemetryMetricsTemporality>,
     ) -> Result<(), GlideOTELError> {
         let env_protocol = protocol_from_env(OtelSignal::Metrics);
+        let temporality = temporality.map(Temporality::from);
         // The async-runtime `PeriodicReader<E>` is generic over the exporter
         // type, so the file and OTLP readers are distinct concrete types. Build
         // the `SdkMeterProvider` inside each arm to keep the reader type local.
         let meter_provider = match metrics_exporter {
             GlideOpenTelemetrySignalsExporter::File(p) => {
-                let exporter = crate::FileMetricExporter::new(p.clone()).map_err(|e| {
+                let exporter = crate::FileMetricExporter::new_with_temporality(
+                    p.clone(),
+                    temporality.unwrap_or(Temporality::Cumulative),
+                )
+                .map_err(|e| {
                     GlideOTELError::Other(format!("Failed to create metrics exporter: {}", e))
                 })?;
                 // The file exporter performs synchronous IO, so the
@@ -904,16 +1004,28 @@ impl GlideOpenTelemetry {
             GlideOpenTelemetrySignalsExporter::Http(url) => {
                 let protocol = env_protocol.unwrap_or(Protocol::HttpBinary);
                 let exporter = match protocol {
-                    Protocol::Grpc => MetricExporter::builder()
-                        .with_tonic()
-                        .with_endpoint(url)
-                        .with_protocol(Protocol::Grpc)
-                        .build()?,
-                    p => MetricExporter::builder()
-                        .with_http()
-                        .with_endpoint(url)
-                        .with_protocol(p)
-                        .build()?,
+                    Protocol::Grpc => {
+                        let builder = MetricExporter::builder()
+                            .with_tonic()
+                            .with_endpoint(url)
+                            .with_protocol(Protocol::Grpc)
+                            .with_metadata(Self::metadata_from_headers(headers)?);
+                        match temporality {
+                            Some(temporality) => builder.with_temporality(temporality).build()?,
+                            None => builder.build()?,
+                        }
+                    }
+                    p => {
+                        let builder = MetricExporter::builder()
+                            .with_http()
+                            .with_endpoint(url)
+                            .with_protocol(p)
+                            .with_http_client(Self::http_client_from_headers(headers)?);
+                        match temporality {
+                            Some(temporality) => builder.with_temporality(temporality).build()?,
+                            None => builder.build()?,
+                        }
+                    }
                 };
                 let reader = opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader::builder(exporter, Tokio)
                     .with_interval(flush_interval_ms)
@@ -931,16 +1043,28 @@ impl GlideOpenTelemetry {
                     );
                 }
                 let exporter = match protocol {
-                    Protocol::Grpc => MetricExporter::builder()
-                        .with_tonic()
-                        .with_endpoint(url)
-                        .with_protocol(Protocol::Grpc)
-                        .build()?,
-                    p => MetricExporter::builder()
-                        .with_http()
-                        .with_endpoint(url)
-                        .with_protocol(p)
-                        .build()?,
+                    Protocol::Grpc => {
+                        let builder = MetricExporter::builder()
+                            .with_tonic()
+                            .with_endpoint(url)
+                            .with_protocol(Protocol::Grpc)
+                            .with_metadata(Self::metadata_from_headers(headers)?);
+                        match temporality {
+                            Some(temporality) => builder.with_temporality(temporality).build()?,
+                            None => builder.build()?,
+                        }
+                    }
+                    p => {
+                        let builder = MetricExporter::builder()
+                            .with_http()
+                            .with_endpoint(url)
+                            .with_protocol(p)
+                            .with_http_client(Self::http_client_from_headers(headers)?);
+                        match temporality {
+                            Some(temporality) => builder.with_temporality(temporality).build()?,
+                            None => builder.build()?,
+                        }
+                    }
                 };
                 let reader = opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader::builder(exporter, Tokio)
                     .with_interval(flush_interval_ms)
@@ -1256,6 +1380,27 @@ mod tests {
     fn string_property_to_u64(json: &serde_json::Value, prop: &str) -> u64 {
         let s = json[prop].to_string().replace('"', "");
         s.parse::<u64>().unwrap()
+    }
+
+    #[test]
+    fn metrics_exporter_config_preserves_headers_and_temporality() {
+        let headers = HashMap::from([("x-routing-header".to_string(), "test-value".to_string())]);
+        let config = GlideOpenTelemetryConfigBuilder::default()
+            .with_metrics_exporter_config(
+                GlideOpenTelemetrySignalsExporter::Http(
+                    "http://localhost:4318/v1/metrics".to_string(),
+                ),
+                headers.clone(),
+                Some(GlideOpenTelemetryMetricsTemporality::Delta),
+            )
+            .build();
+
+        let metrics = config.metrics.expect("metrics config should be present");
+        assert_eq!(metrics.headers, headers);
+        assert_eq!(
+            metrics.temporality,
+            Some(GlideOpenTelemetryMetricsTemporality::Delta)
+        );
     }
 
     /// Helper function to find a metric by name in the metrics array

--- a/glide-core/telemetry/src/open_telemetry.rs
+++ b/glide-core/telemetry/src/open_telemetry.rs
@@ -32,6 +32,7 @@ use url::Url;
 const SPAN_WRITE_LOCK_ERR: &str = "Failed to acquire span write lock";
 const SPAN_READ_LOCK_ERR: &str = "Failed to acquire span read lock";
 const TRACE_SCOPE: &str = "valkey_glide";
+const DEFAULT_OTLP_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
 
 // Metric names
 const TIMEOUT_ERROR_METRIC: &str = "glide.timeout_errors";
@@ -705,12 +706,30 @@ impl GlideOpenTelemetry {
         }
         reqwest::Client::builder()
             .default_headers(default_headers)
+            .timeout(Self::metrics_http_timeout())
             .build()
             .map_err(|error| {
                 GlideOTELError::Other(format!(
                     "Failed to build OpenTelemetry metrics HTTP client: {error}"
                 ))
             })
+    }
+
+    fn metrics_http_timeout() -> Duration {
+        let metrics_timeout = std::env::var("OTEL_EXPORTER_OTLP_METRICS_TIMEOUT").ok();
+        let general_timeout = std::env::var("OTEL_EXPORTER_OTLP_TIMEOUT").ok();
+        Self::metrics_http_timeout_from(metrics_timeout.as_deref(), general_timeout.as_deref())
+    }
+
+    fn metrics_http_timeout_from(
+        metrics_timeout: Option<&str>,
+        general_timeout: Option<&str>,
+    ) -> Duration {
+        metrics_timeout
+            .and_then(|value| value.parse().ok())
+            .or_else(|| general_timeout.and_then(|value| value.parse().ok()))
+            .map(Duration::from_millis)
+            .unwrap_or(DEFAULT_OTLP_EXPORT_TIMEOUT)
     }
 
     fn metadata_from_headers(
@@ -1016,11 +1035,14 @@ impl GlideOpenTelemetry {
                         }
                     }
                     p => {
-                        let builder = MetricExporter::builder()
+                        let mut builder = MetricExporter::builder()
                             .with_http()
                             .with_endpoint(url)
-                            .with_protocol(p)
-                            .with_http_client(Self::http_client_from_headers(headers)?);
+                            .with_protocol(p);
+                        if !headers.is_empty() {
+                            builder =
+                                builder.with_http_client(Self::http_client_from_headers(headers)?);
+                        }
                         match temporality {
                             Some(temporality) => builder.with_temporality(temporality).build()?,
                             None => builder.build()?,
@@ -1055,11 +1077,14 @@ impl GlideOpenTelemetry {
                         }
                     }
                     p => {
-                        let builder = MetricExporter::builder()
+                        let mut builder = MetricExporter::builder()
                             .with_http()
                             .with_endpoint(url)
-                            .with_protocol(p)
-                            .with_http_client(Self::http_client_from_headers(headers)?);
+                            .with_protocol(p);
+                        if !headers.is_empty() {
+                            builder =
+                                builder.with_http_client(Self::http_client_from_headers(headers)?);
+                        }
                         match temporality {
                             Some(temporality) => builder.with_temporality(temporality).build()?,
                             None => builder.build()?,
@@ -1400,6 +1425,40 @@ mod tests {
         assert_eq!(
             metrics.temporality,
             Some(GlideOpenTelemetryMetricsTemporality::Delta)
+        );
+    }
+
+    #[test]
+    fn metrics_http_timeout_matches_otlp_environment_precedence() {
+        assert_eq!(
+            GlideOpenTelemetry::metrics_http_timeout_from(None, None),
+            DEFAULT_OTLP_EXPORT_TIMEOUT
+        );
+        assert_eq!(
+            GlideOpenTelemetry::metrics_http_timeout_from(Some("2500"), Some("5000")),
+            Duration::from_millis(2500)
+        );
+        assert_eq!(
+            GlideOpenTelemetry::metrics_http_timeout_from(Some("invalid"), Some("5000")),
+            Duration::from_millis(5000)
+        );
+    }
+
+    #[test]
+    fn grpc_metadata_preserves_header_value_and_normalizes_name() {
+        let metadata = GlideOpenTelemetry::metadata_from_headers(&HashMap::from([(
+            "X-Routing-Header".to_string(),
+            "serviceName:test,instanceId:i-1".to_string(),
+        )]))
+        .expect("metadata should be valid");
+
+        assert_eq!(
+            metadata
+                .get("x-routing-header")
+                .expect("routing header should be present")
+                .to_str()
+                .expect("routing header should be ASCII"),
+            "serviceName:test,instanceId:i-1"
         );
     }
 

--- a/glide-core/telemetry/tests/test_metrics_export.rs
+++ b/glide-core/telemetry/tests/test_metrics_export.rs
@@ -191,6 +191,15 @@ async fn test_exporter_temporality() {
 }
 
 #[tokio::test]
+async fn test_exporter_custom_temporality() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let file_path = temp_dir.path().join("delta-temporality.json");
+    let exporter = FileMetricExporter::new_with_temporality(file_path, Temporality::Delta)
+        .expect("Failed to create exporter");
+    assert_eq!(exporter.temporality(), Temporality::Delta);
+}
+
+#[tokio::test]
 async fn test_gauge_i64_export_success() {
     let (provider, exporter) = provider_with_exporter();
     let meter = provider.meter("test_scope");

--- a/glide-core/telemetry/tests/test_otlp_metrics_config.rs
+++ b/glide-core/telemetry/tests/test_otlp_metrics_config.rs
@@ -1,0 +1,133 @@
+// Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
+
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::metrics::v1::{AggregationTemporality, metric};
+use prost::Message;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use telemetrylib::{
+    GlideOpenTelemetry, GlideOpenTelemetryConfigBuilder, GlideOpenTelemetryMetricsTemporality,
+    GlideOpenTelemetrySignalsExporter,
+};
+
+struct CapturedRequest {
+    headers: String,
+    body: Vec<u8>,
+}
+
+fn read_request(mut stream: TcpStream) -> CapturedRequest {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("failed to set read timeout");
+
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let count = stream.read(&mut buffer).expect("failed to read request");
+        assert!(
+            count > 0,
+            "connection closed before request headers arrived"
+        );
+        request.extend_from_slice(&buffer[..count]);
+        if let Some(position) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+
+    let headers =
+        String::from_utf8(request[..header_end].to_vec()).expect("headers were not valid UTF-8");
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .map(str::trim)
+                .map(str::parse::<usize>)
+        })
+        .expect("request did not contain Content-Length")
+        .expect("Content-Length was not a number");
+
+    while request.len() - header_end < content_length {
+        let count = stream
+            .read(&mut buffer)
+            .expect("failed to read request body");
+        assert!(count > 0, "connection closed before request body arrived");
+        request.extend_from_slice(&buffer[..count]);
+    }
+
+    stream
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+        .expect("failed to write response");
+
+    CapturedRequest {
+        headers,
+        body: request[header_end..header_end + content_length].to_vec(),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn programmatic_headers_and_delta_temporality_are_exported() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind test collector");
+    let address = listener
+        .local_addr()
+        .expect("failed to get collector address");
+    let (sender, receiver) = mpsc::sync_channel(1);
+
+    let collector = thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("failed to accept OTLP request");
+        sender
+            .send(read_request(stream))
+            .expect("failed to return captured request");
+    });
+
+    let config = GlideOpenTelemetryConfigBuilder::default()
+        .with_flush_interval(Duration::from_millis(20))
+        .with_metrics_exporter_config(
+            GlideOpenTelemetrySignalsExporter::Http(format!("http://{address}/v1/metrics")),
+            HashMap::from([(
+                "X-Test-Routing-Header".to_string(),
+                "test%2Fvalue".to_string(),
+            )]),
+            Some(GlideOpenTelemetryMetricsTemporality::Delta),
+        )
+        .build();
+
+    GlideOpenTelemetry::initialise(config).expect("failed to initialize OpenTelemetry");
+    GlideOpenTelemetry::record_timeout_error().expect("failed to record test metric");
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("timed out waiting for OTLP metrics export");
+    collector.join().expect("test collector panicked");
+
+    assert!(
+        request
+            .headers
+            .to_ascii_lowercase()
+            .contains("x-test-routing-header: test%2fvalue\r\n"),
+        "custom routing header was not exported: {}",
+        request.headers
+    );
+
+    let export = ExportMetricsServiceRequest::decode(request.body.as_slice())
+        .expect("failed to decode OTLP protobuf request");
+    let timeout_metric = export
+        .resource_metrics
+        .iter()
+        .flat_map(|resource| &resource.scope_metrics)
+        .flat_map(|scope| &scope.metrics)
+        .find(|metric| metric.name == "glide.timeout_errors")
+        .expect("timeout metric was not exported");
+    let sum = match timeout_metric.data.as_ref() {
+        Some(metric::Data::Sum(sum)) => sum,
+        data => panic!("timeout metric was not exported as a sum: {data:?}"),
+    };
+    assert_eq!(
+        sum.aggregation_temporality,
+        AggregationTemporality::Delta as i32
+    );
+}

--- a/java/Cargo.lock
+++ b/java/Cargo.lock
@@ -2704,10 +2704,12 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
  "url",
 ]
 

--- a/java/client/src/main/java/glide/api/OpenTelemetry.java
+++ b/java/client/src/main/java/glide/api/OpenTelemetry.java
@@ -4,6 +4,9 @@ package glide.api;
 import glide.api.logging.Logger;
 import glide.api.models.exceptions.ConfigurationError;
 import glide.ffi.resolvers.OpenTelemetryResolver;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 
 /**
@@ -41,6 +44,8 @@ import java.util.Random;
  *             <ul>
  *               <li><b>endpoint</b>: The collector endpoint for metrics. Same protocol rules as
  *                   above.
+ *               <li><b>headers</b>: (optional) Additional headers sent with each export request.
+ *               <li><b>temporality</b>: (optional) Aggregation temporality for exported metrics.
  *             </ul>
  *         <li><b>flushIntervalMs</b>: (optional) Interval in milliseconds for flushing data to the
  *             collector. Must be a positive integer. Defaults to 5000ms if not specified.
@@ -280,6 +285,25 @@ public class OpenTelemetry {
     /** Configuration for OpenTelemetry metrics. */
     public static class MetricsConfig {
         private String endpoint;
+        private Map<String, String> headers = Collections.emptyMap();
+        private MetricsTemporality temporality;
+
+        /** Aggregation temporality used when exporting metrics. */
+        public enum MetricsTemporality {
+            CUMULATIVE("cumulative"),
+            DELTA("delta"),
+            LOW_MEMORY("lowmemory");
+
+            private final String value;
+
+            MetricsTemporality(String value) {
+                this.value = value;
+            }
+
+            String getValue() {
+                return value;
+            }
+        }
 
         /**
          * Creates a new MetricsConfig builder.
@@ -293,6 +317,8 @@ public class OpenTelemetry {
         /** Builder for MetricsConfig. */
         public static class Builder {
             private String endpoint;
+            private Map<String, String> headers = Collections.emptyMap();
+            private MetricsTemporality temporality;
 
             /**
              * Sets the endpoint for metrics.
@@ -306,6 +332,31 @@ public class OpenTelemetry {
             }
 
             /**
+             * Sets additional headers to send with every metrics export request.
+             *
+             * @param headers The metrics exporter headers
+             * @return This builder
+             */
+            public Builder headers(Map<String, String> headers) {
+                this.headers =
+                        headers == null
+                                ? Collections.emptyMap()
+                                : Collections.unmodifiableMap(new HashMap<>(headers));
+                return this;
+            }
+
+            /**
+             * Sets the aggregation temporality for exported metrics.
+             *
+             * @param temporality The metrics aggregation temporality
+             * @return This builder
+             */
+            public Builder temporality(MetricsTemporality temporality) {
+                this.temporality = temporality;
+                return this;
+            }
+
+            /**
              * Builds the MetricsConfig.
              *
              * @return The built MetricsConfig
@@ -313,6 +364,8 @@ public class OpenTelemetry {
             public MetricsConfig build() {
                 MetricsConfig config = new MetricsConfig();
                 config.endpoint = this.endpoint;
+                config.headers = this.headers;
+                config.temporality = this.temporality;
                 return config;
             }
         }
@@ -326,9 +379,29 @@ public class OpenTelemetry {
             return endpoint;
         }
 
+        /**
+         * Gets the additional metrics exporter headers.
+         *
+         * @return An immutable map of metrics exporter headers
+         */
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+
+        /**
+         * Gets the metrics aggregation temporality.
+         *
+         * @return The configured temporality, or null when the exporter default is used
+         */
+        public MetricsTemporality getTemporality() {
+            return temporality;
+        }
+
         MetricsConfig copy() {
             MetricsConfig clone = new MetricsConfig();
             clone.endpoint = this.endpoint;
+            clone.headers = this.headers;
+            clone.temporality = this.temporality;
             return clone;
         }
     }
@@ -354,6 +427,8 @@ public class OpenTelemetry {
      *          .metrics(
      *             OpenTelemetry.MetricsConfig.builder()
      *                 .endpoint("http://localhost:4318/v1/metrics")
+     *                 .headers(Collections.singletonMap("Authorization", "Bearer token"))
+     *                 .temporality(OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA)
      *                 .build()
      *          )
      *         .flushIntervalMs(5000L) // Optional, defaults to 5000
@@ -390,9 +465,23 @@ public class OpenTelemetry {
         }
 
         String metricsEndpoint = null;
+        String[] metricsHeaderKeys = new String[0];
+        String[] metricsHeaderValues = new String[0];
+        String metricsTemporality = null;
         MetricsConfig metricsConfig = config.getMetrics();
         if (metricsConfig != null) {
             metricsEndpoint = metricsConfig.getEndpoint();
+            metricsHeaderKeys = new String[metricsConfig.getHeaders().size()];
+            metricsHeaderValues = new String[metricsConfig.getHeaders().size()];
+            int headerIndex = 0;
+            for (Map.Entry<String, String> header : metricsConfig.getHeaders().entrySet()) {
+                metricsHeaderKeys[headerIndex] = header.getKey();
+                metricsHeaderValues[headerIndex] = header.getValue();
+                headerIndex++;
+            }
+            if (metricsConfig.getTemporality() != null) {
+                metricsTemporality = metricsConfig.getTemporality().getValue();
+            }
         }
 
         long flushIntervalMs =
@@ -400,7 +489,13 @@ public class OpenTelemetry {
 
         int rc =
                 OpenTelemetryResolver.initOpenTelemetry(
-                        tracesEndpoint, tracesSamplePercentage, metricsEndpoint, flushIntervalMs);
+                        tracesEndpoint,
+                        tracesSamplePercentage,
+                        metricsEndpoint,
+                        metricsHeaderKeys,
+                        metricsHeaderValues,
+                        metricsTemporality,
+                        flushIntervalMs);
         if (rc != 0) {
             String msg;
             switch (rc) {

--- a/java/client/src/main/java/glide/ffi/resolvers/OpenTelemetryResolver.java
+++ b/java/client/src/main/java/glide/ffi/resolvers/OpenTelemetryResolver.java
@@ -17,6 +17,9 @@ public class OpenTelemetryResolver {
      * @param tracesEndpoint The endpoint for traces exporter (can be null if not used)
      * @param tracesSamplePercentage The percentage of requests to sample (0 for default)
      * @param metricsEndpoint The endpoint for metrics exporter (can be null if not used)
+     * @param metricsHeaderKeys The names of additional metrics exporter headers
+     * @param metricsHeaderValues The values of additional metrics exporter headers
+     * @param metricsTemporality The metrics aggregation temporality (can be null for default)
      * @param flushIntervalMs The interval in milliseconds between consecutive exports (0 for default)
      * @return 0 on success, error code otherwise: 1 - Missing configuration (both traces and metrics
      *     are null) 2 - Invalid traces endpoint 3 - Invalid metrics endpoint 4 - Runtime
@@ -26,6 +29,9 @@ public class OpenTelemetryResolver {
             String tracesEndpoint,
             int tracesSamplePercentage,
             String metricsEndpoint,
+            String[] metricsHeaderKeys,
+            String[] metricsHeaderValues,
+            String metricsTemporality,
             long flushIntervalMs);
 
     /**

--- a/java/integTest/src/test/java/glide/OpenTelemetryConfigTests.java
+++ b/java/integTest/src/test/java/glide/OpenTelemetryConfigTests.java
@@ -49,19 +49,18 @@ public class OpenTelemetryConfigTests {
     @Test
     public void metricsConfigSupportsHeadersAndTemporality() {
         Map<String, String> headers = new HashMap<>();
-        headers.put("X-LI-Fluentbit-Tag", "serviceName:test-service");
+        headers.put("X-Routing-Header", "tenant:test");
 
         OpenTelemetry.MetricsConfig metricsConfig =
                 OpenTelemetry.MetricsConfig.builder()
-                        .endpoint("http://[::1]:22784/v1/metrics")
+                        .endpoint("http://localhost:4318/v1/metrics")
                         .headers(headers)
                         .temporality(OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA)
                         .build();
         headers.put("unexpected", "mutation");
 
         assertEquals(
-                Collections.singletonMap("X-LI-Fluentbit-Tag", "serviceName:test-service"),
-                metricsConfig.getHeaders());
+                Collections.singletonMap("X-Routing-Header", "tenant:test"), metricsConfig.getHeaders());
         assertEquals(
                 OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA, metricsConfig.getTemporality());
         assertThrows(

--- a/java/integTest/src/test/java/glide/OpenTelemetryConfigTests.java
+++ b/java/integTest/src/test/java/glide/OpenTelemetryConfigTests.java
@@ -1,12 +1,16 @@
 /** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
 package glide;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import glide.api.OpenTelemetry;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -24,6 +28,45 @@ public class OpenTelemetryConfigTests {
         Path tempDir = Files.createTempDirectory("otel-test");
         VALID_ENDPOINT_TRACES = tempDir.resolve("spans.json").toString();
         VALID_FILE_ENDPOINT_TRACES = "file://" + VALID_ENDPOINT_TRACES;
+    }
+
+    @Test
+    public void invalidMetricsHeaderIsRejectedByNativeExporter() {
+        OpenTelemetry.OpenTelemetryConfig invalidHeaderConfig =
+                OpenTelemetry.OpenTelemetryConfig.builder()
+                        .metrics(
+                                OpenTelemetry.MetricsConfig.builder()
+                                        .endpoint("http://localhost:4318/v1/metrics")
+                                        .headers(Collections.singletonMap("x-test-header", "invalid\nvalue"))
+                                        .build())
+                        .build();
+
+        Exception exception =
+                assertThrows(Exception.class, () -> OpenTelemetry.init(invalidHeaderConfig));
+        assertTrue(exception.getMessage().contains("Invalid OpenTelemetry metrics header value"));
+    }
+
+    @Test
+    public void metricsConfigSupportsHeadersAndTemporality() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("X-LI-Fluentbit-Tag", "serviceName:test-service");
+
+        OpenTelemetry.MetricsConfig metricsConfig =
+                OpenTelemetry.MetricsConfig.builder()
+                        .endpoint("http://[::1]:22784/v1/metrics")
+                        .headers(headers)
+                        .temporality(OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA)
+                        .build();
+        headers.put("unexpected", "mutation");
+
+        assertEquals(
+                Collections.singletonMap("X-LI-Fluentbit-Tag", "serviceName:test-service"),
+                metricsConfig.getHeaders());
+        assertEquals(
+                OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA, metricsConfig.getTemporality());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> metricsConfig.getHeaders().put("another", "mutation"));
     }
 
     // Test wrong open telemetry configs

--- a/java/integTest/src/test/java/glide/OpenTelemetryTests.java
+++ b/java/integTest/src/test/java/glide/OpenTelemetryTests.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -175,7 +176,12 @@ public class OpenTelemetryTests {
                                         .endpoint(VALID_FILE_ENDPOINT_TRACES)
                                         .samplePercentage(100)
                                         .build())
-                        .metrics(OpenTelemetry.MetricsConfig.builder().endpoint(VALID_ENDPOINT_METRICS).build())
+                        .metrics(
+                                OpenTelemetry.MetricsConfig.builder()
+                                        .endpoint(VALID_ENDPOINT_METRICS)
+                                        .headers(Collections.singletonMap("x-test-routing-header", "test-value"))
+                                        .temporality(OpenTelemetry.MetricsConfig.MetricsTemporality.DELTA)
+                                        .build())
                         .flushIntervalMs(100L)
                         .build();
 

--- a/java/src/lib.rs
+++ b/java/src/lib.rs
@@ -982,6 +982,9 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_initOpenTe
     traces_endpoint: JString<'local>,
     traces_sample_percentage: jint,
     metrics_endpoint: JString<'local>,
+    metrics_header_keys: JObjectArray<'local>,
+    metrics_header_values: JObjectArray<'local>,
+    metrics_temporality: JString<'local>,
     flush_interval_ms: jlong,
 ) -> jint {
     run_ffi(|| {
@@ -990,6 +993,9 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_initOpenTe
                 traces_endpoint: JString<'a>,
                 traces_sample_percentage: jint,
                 metrics_endpoint: JString<'a>,
+                metrics_header_keys: JObjectArray<'a>,
+                metrics_header_values: JObjectArray<'a>,
+                metrics_temporality: JString<'a>,
                 flush_interval_ms: jlong,
             ) -> Result<jint, FFIError> {
                 // Convert JString to Rust String or None if null
@@ -1003,6 +1009,50 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_initOpenTe
                     Ok(endpoint) => Some(endpoint.into()),
                     Err(JniError::NullPtr(_)) => None,
                     Err(err) => return Err(err.into()),
+                };
+
+                let header_key_count = env.get_array_length(&metrics_header_keys)?;
+                let header_value_count = env.get_array_length(&metrics_header_values)?;
+                if header_key_count != header_value_count {
+                    return Err(FFIError::OpenTelemetry(
+                        "Metrics header keys and values must have the same length.".to_string(),
+                    ));
+                }
+                let mut metrics_headers =
+                    std::collections::HashMap::with_capacity(header_key_count as usize);
+                for index in 0..header_key_count {
+                    let key =
+                        JString::from(env.get_object_array_element(&metrics_header_keys, index)?);
+                    let value =
+                        JString::from(env.get_object_array_element(&metrics_header_values, index)?);
+                    metrics_headers.insert(
+                        env.get_string(&key)?.into(),
+                        env.get_string(&value)?.into(),
+                    );
+                }
+
+                let metrics_temporality: Option<String> =
+                    match env.get_string(&metrics_temporality) {
+                        Ok(temporality) => Some(temporality.into()),
+                        Err(JniError::NullPtr(_)) => None,
+                        Err(err) => return Err(err.into()),
+                    };
+                let metrics_temporality = match metrics_temporality.as_deref() {
+                    Some("cumulative") => {
+                        Some(glide_core::GlideOpenTelemetryMetricsTemporality::Cumulative)
+                    }
+                    Some("delta") => {
+                        Some(glide_core::GlideOpenTelemetryMetricsTemporality::Delta)
+                    }
+                    Some("lowmemory") => {
+                        Some(glide_core::GlideOpenTelemetryMetricsTemporality::LowMemory)
+                    }
+                    Some(value) => {
+                        return Err(FFIError::OpenTelemetry(format!(
+                            "Invalid metrics temporality: {value}"
+                        )));
+                    }
+                    None => None,
                 };
 
                 // Validate that at least one endpoint is provided
@@ -1038,9 +1088,11 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_initOpenTe
 
                 // Initialize metrics exporter if endpoint is provided
                 if let Some(endpoint) = metrics_endpoint {
-                    config = config.with_metrics_exporter(
+                    config = config.with_metrics_exporter_config(
                         glide_core::GlideOpenTelemetrySignalsExporter::from_str(&endpoint)
                             .map_err(|e| FFIError::OpenTelemetry(format!("{e}")))?,
+                        metrics_headers,
+                        metrics_temporality,
                     );
                 }
 
@@ -1073,7 +1125,16 @@ pub extern "system" fn Java_glide_ffi_resolvers_OpenTelemetryResolver_initOpenTe
 
                 Ok(0 as jint)
             }
-            let result = init_open_telemetry(&mut env, traces_endpoint, traces_sample_percentage, metrics_endpoint, flush_interval_ms);
+            let result = init_open_telemetry(
+                &mut env,
+                traces_endpoint,
+                traces_sample_percentage,
+                metrics_endpoint,
+                metrics_header_keys,
+                metrics_header_values,
+                metrics_temporality,
+                flush_interval_ms,
+            );
             handle_errors(&mut env, result)
         },
     )


### PR DESCRIPTION
## Summary

- add programmatic metrics headers and aggregation temporality to the Java OpenTelemetry API
- carry the configuration through JNI into HTTP, gRPC, and file metrics exporters
- preserve header values verbatim and retain standard OTLP HTTP timeout behavior
- validate invalid headers at exporter initialization

## Testing

- `cargo test -- --test-threads=1`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --manifest-path glide-core/Cargo.toml --all -- --check`
- `./gradlew spotlessCheck`
- `./gradlew :integTest:test --tests 'glide.OpenTelemetryConfigTests.*'`
- `./gradlew :integTest:test --tests 'glide.OpenTelemetryTests.*'`

The OTLP integration test starts a local collector, captures an actual metrics export request, verifies the configured routing header, decodes the protobuf payload, and asserts that the emitted counter uses DELTA temporality.
