### PR TITLE
Go: Fix flaky TestScriptKillWithRoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Fixes
 
-* Go: Fix flaky TestScriptKillWithRoute ([#6941](https://github.com/valkey-io/valkey-glide/pull/6941))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Go: Fix flaky TestScriptKillWithRoute ([#6941](https://github.com/valkey-io/valkey-glide/pull/6941))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))

--- a/go/integTest/cluster_commands_test.go
+++ b/go/integTest/cluster_commands_test.go
@@ -2801,8 +2801,10 @@ func (suite *GlideTestSuite) TestScriptKillWithoutRoute() {
 func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	killClient := suite.defaultClusterClient()
 
-	// Use a longer request timeout so InvokeScript blocks until killed
-	invokeConfig := suite.defaultClusterClientConfig().WithRequestTimeout(12 * time.Second)
+	// Use a longer request timeout so InvokeScript blocks until killed.
+	// It must comfortably exceed the kill poll window below so the invocation
+	// stays blocked until the SCRIPT KILL lands.
+	invokeConfig := suite.defaultClusterClientConfig().WithRequestTimeout(20 * time.Second)
 	invokeClient, err := suite.clusterClient(invokeConfig)
 	require.NoError(suite.T(), err)
 
@@ -2817,8 +2819,12 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 	assert.Error(suite.T(), err)
 	assert.True(suite.T(), strings.Contains(strings.ToLower(err.Error()), "notbusy"))
 
-	// Kill Running Code
-	code := CreateLongRunningLuaScript(10, true)
+	// Kill Running Code.
+	// The script's self-timeout (15s) is kept comfortably larger than the kill
+	// poll window (10s) below, so the script stays busy for the entire duration
+	// the test polls SCRIPT KILL. This removes the previous race where the
+	// script could self-terminate before a kill landed, leaving nothing to kill.
+	code := CreateLongRunningLuaScript(15, true)
 	script := options.NewScript(code)
 
 	// Start InvokeScript in a goroutine so it begins executing immediately
@@ -2829,13 +2835,19 @@ func (suite *GlideTestSuite) TestScriptKillWithRoute() {
 		_, invokeErr = invokeClient.InvokeScriptWithRoute(context.Background(), *script, route)
 	}()
 
-	// Poll ScriptKill on the main goroutine until the script is running and killed
+	// Poll ScriptKill on the main goroutine until the script is running and killed.
+	// A tighter poll interval gives more attempts to catch the busy window.
+	// Any transient error (NOTBUSY before the script is registered as busy, or a
+	// NoScriptError in the brief window around kill/finish) simply returns false
+	// and keeps polling; only a successful kill (killErr == nil) satisfies the
+	// condition. The 10s window is smaller than the script's 15s busy window, so
+	// a kill is guaranteed to land while the script is still running.
 	var killErr error
 	var result string
 	require.Eventually(suite.T(), func() bool {
 		result, killErr = killClient.ScriptKillWithRoute(context.Background(), route)
 		return killErr == nil
-	}, 10*time.Second, 500*time.Millisecond, "Timed out waiting for script kill to succeed")
+	}, 10*time.Second, 250*time.Millisecond, "Timed out waiting for script kill to succeed")
 
 	// Wait for invoke to complete after kill
 	<-invokeDone


### PR DESCRIPTION
### Summary

Fixes the flaky Go integration test `TestGlideTestSuite/TestScriptKillWithRoute` (`go/integTest/cluster_commands_test.go`).

### Issue link

This Pull Request is linked to issue: [\[Go\]\[Flaky Test\] TestGlideTestSuite/TestScriptKillWithRoute](https://github.com/valkey-io/valkey-glide/issues/6939)
Closes #6939

### Features / Behaviour Changes

No behaviour changes. Test-only timing fix.

### Implementation

Root cause: the `require.Eventually` kill-poll window (10s) was equal to the Lua script's self-timeout (`CreateLongRunningLuaScript(10, true)` ≈ 10s busy). With no slack for script startup/registration latency (network + FFI + cluster routing), the script could self-terminate (returning normally) at ~t=10s before a `SCRIPT KILL` landed within the poll window. Once the script ends, `SCRIPT KILL` returns `NOTBUSY`, so the `Eventually` condition (`killErr == nil`) was never satisfied → "Condition never satisfied / Timed out waiting for script kill to succeed".

Fix — decouple the script busy window from the kill-poll window so a kill is guaranteed to land while the script is still busy:
- Bump the script busy window: `CreateLongRunningLuaScript(10, true)` → `CreateLongRunningLuaScript(15, true)` (15s now strictly exceeds the 10s poll window).
- Bump the invocation `RequestTimeout`: 12s → 20s so the invocation stays blocked until the kill lands and a request timeout never masks the "script killed" assertion.
- Tighten the poll interval: 500ms → 250ms for more kill attempts during the busy window.

No assertions changed; no `time.Sleep` added (uses the existing `require.Eventually` polling).

### Limitations

None.

### Testing

Ran the target test 100× locally against a self-hosted Valkey cluster (release build): **100/100 passed**.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.