### PR TITLE
Core: Fix flaky test_create_client_from_uri_simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Fix flaky test_create_client_from_uri_simple ([#6942](https://github.com/valkey-io/valkey-glide/pull/6942))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))

--- a/ffi/tests/test_create_client_from_uri.rs
+++ b/ffi/tests/test_create_client_from_uri.rs
@@ -1,10 +1,10 @@
 use glide_ffi::*;
 use rstest::rstest;
 use std::ffi::{CStr, CString, c_char};
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command};
 use std::ptr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 // TODO: Move RedisServer implementation from glide-core tests to a reusable library and replace this Server implementation.
 struct Server {
@@ -55,9 +55,34 @@ impl Server {
             }
         };
 
-        // Give the server some time to start
-        std::thread::sleep(Duration::from_millis(500));
+        // Wait for the server to actually accept connections instead of
+        // sleeping a fixed duration. On busy CI runners a fixed 500ms sleep
+        // was not always long enough for the server to bind and start
+        // listening, causing the client to time out while connecting. Poll
+        // the port until a TCP connection succeeds, with a short backoff
+        // between attempts and a generous overall timeout.
+        Self::wait_until_ready(port);
         child
+    }
+
+    /// Polls the server port until it accepts TCP connections, or panics if it
+    /// does not become ready within the timeout. This replaces a fixed sleep so
+    /// the tests do not race a slow-starting server on busy CI machines.
+    fn wait_until_ready(port: u16) {
+        let addr = format!("127.0.0.1:{port}");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            match TcpStream::connect(&addr) {
+                Ok(_) => return,
+                Err(e) => {
+                    if Instant::now() >= deadline {
+                        panic!("Server on {addr} did not become ready within timeout: {e}");
+                    }
+                    // Short backoff between connection attempts.
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Summary

Fixes the flaky Rust FFI test `test_create_client_from_uri_simple` (`ffi/tests/test_create_client_from_uri.rs`).

### Issue link

This Pull Request is linked to issue: [\[Rust\]\[Flaky Test\] test_create_client_from_uri_simple](https://github.com/valkey-io/valkey-glide/issues/6940)
Closes #6940

### Features / Behaviour Changes

No behaviour changes. Test-helper timing fix.

### Implementation

Root cause: the test helper `Server::start_server` spawned `valkey-server`/`redis-server` and then waited a fixed `std::thread::sleep(Duration::from_millis(500))` before returning. On busy CI runners 500ms was not always enough for the server to bind and start accepting connections, so the FFI client's connect timed out (`Received error for address 127.0.0.1:<port>: timed out`). The whole test file shares this helper.

Fix — replace the fixed sleep with an active readiness poll (`wait_until_ready`) that repeatedly attempts `TcpStream::connect` to `127.0.0.1:<port>` until it succeeds, with a 50ms backoff between attempts and a 30s overall deadline (panics with a clear message if the server never becomes ready). This guarantees the server is accepting connections before the client connects, for both `requirepass` and non-`requirepass` servers. No test assertions changed.

### Limitations

None.

### Testing

Ran `test_create_client_from_uri_simple` 100× locally against a freshly started Valkey server: **100/100 passed**. Full test file compiles cleanly.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.