### PR TITLE
fix(java): decode scoped-connection responses larger than 16 KB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Java: Fix scoped connection truncating values larger than 16 KB ([#6893](https://github.com/valkey-io/valkey-glide/issues/6893))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))
 * Core: retry empty-receivers multi-node fan-out under topology churn ([#6768](https://github.com/valkey-io/valkey-glide/pull/6768))

--- a/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
+++ b/java/client/src/main/java/glide/api/models/scope/IsolatedScope.java
@@ -3,6 +3,7 @@ package glide.api.models.scope;
 
 import glide.ffi.resolvers.GlideScopeResolver;
 import glide.internal.AsyncRegistry;
+import glide.managers.DirectBufferResolver;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -97,8 +98,17 @@ public class IsolatedScope implements AutoCloseable {
     }
 
     public CompletableFuture<String> cmd(String command, String... args) {
+        return command(command, args).thenApply(IsolatedScope::asString);
+    }
+
+    /**
+     * Execute a command and return the decoded response object, using the same decoder as a normal
+     * client so a scope sees the same value regardless of its size. Bulk values come back as {@link
+     * String}, arrays as {@code Object[]}, and maps as {@link java.util.Map}.
+     */
+    public CompletableFuture<Object> command(String command, String... args) {
         if (released.get()) {
-            CompletableFuture<String> f = new CompletableFuture<>();
+            CompletableFuture<Object> f = new CompletableFuture<>();
             f.completeExceptionally(new IllegalStateException("Scope released"));
             return f;
         }
@@ -113,12 +123,26 @@ public class IsolatedScope implements AutoCloseable {
         else if (result == -2)
             future.completeExceptionally(new IllegalArgumentException("Serialize failed"));
 
-        return future.thenApply(
-                r -> {
-                    if (r == null) return null;
-                    if (r instanceof byte[]) return new String((byte[]) r, StandardCharsets.UTF_8);
-                    return r.toString();
-                });
+        return future.thenApply(IsolatedScope::resolve);
+    }
+
+    /**
+     * The native layer offloads any response over 16 KB into a direct buffer, so decode that back
+     * into a value instead of stringifying the buffer handle. Smaller responses arrive already
+     * decoded and pass through untouched.
+     */
+    private static Object resolve(Object raw) {
+        if (raw instanceof ByteBuffer) {
+            return DirectBufferResolver.normalizeDirectBuffer((ByteBuffer) raw, true);
+        }
+        return raw;
+    }
+
+    private static String asString(Object value) {
+        if (value == null) return null;
+        if (value instanceof String) return (String) value;
+        if (value instanceof byte[]) return new String((byte[]) value, StandardCharsets.UTF_8);
+        return value.toString();
     }
 
     @Override

--- a/java/client/src/main/java/glide/managers/CommandManager.java
+++ b/java/client/src/main/java/glide/managers/CommandManager.java
@@ -26,14 +26,10 @@ import glide.api.models.exceptions.RequestException;
 import glide.ffi.resolvers.ClusterScanCursorResolver;
 import glide.ffi.resolvers.OpenTelemetryResolver;
 import glide.internal.GlideCoreClient;
-import glide.utils.BufferUtils;
 import glide.utils.Java8Utils;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -793,150 +789,13 @@ public class CommandManager {
             builder.setConstantResponse(ConstantResponse.OK);
         } else {
             if (result instanceof ByteBuffer) {
-                toStore = normalizeDirectBuffer((ByteBuffer) result, expectUtf8Response);
+                toStore =
+                        DirectBufferResolver.normalizeDirectBuffer((ByteBuffer) result, expectUtf8Response);
             }
             long objectId = JniResponseRegistry.storeObject(toStore);
             builder.setRespPointer(objectId);
         }
         return builder.build();
-    }
-
-    private Object normalizeDirectBuffer(ByteBuffer buffer, boolean expectUtf8Response) {
-        ByteBuffer dup = buffer.duplicate();
-        dup.order(ByteOrder.BIG_ENDIAN);
-        dup.rewind();
-        if (dup.remaining() == 0) {
-            return expectUtf8Response ? "" : GlideString.gs(new byte[0]);
-        }
-        byte marker = dup.get();
-        dup.rewind();
-        if (marker == '*') {
-            // Serialized array/map (custom wire format)
-            return deserializeByteBufferArray(dup, expectUtf8Response);
-        } else if (marker == '%') {
-            return deserializeByteBufferMap(dup, expectUtf8Response);
-        }
-        // Bulk string bytes
-        if (expectUtf8Response) {
-            // Decode UTF-8 directly from buffer
-            return BufferUtils.decodeUtf8(dup);
-        } else {
-            byte[] bytes = new byte[dup.remaining()];
-            dup.get(bytes);
-            return GlideString.gs(bytes);
-        }
-    }
-
-    /**
-     * Validate that the buffer has at least the required number of bytes remaining.
-     *
-     * @param buffer the buffer to check
-     * @param required the minimum number of bytes required
-     * @param context description of what is being read (for error message)
-     * @throws IllegalArgumentException if buffer has insufficient bytes
-     */
-    private static void requireBufferBytes(ByteBuffer buffer, int required, String context) {
-        if (buffer.remaining() < required) {
-            throw new IllegalArgumentException(
-                    "Buffer too small for " + context + ": " + buffer.remaining() + " bytes");
-        }
-    }
-
-    /**
-     * Validate a length field read from the buffer.
-     *
-     * @param length the length value to validate
-     * @param buffer the buffer to check remaining bytes against
-     * @param typeName description of the data type (for error message), capitalized (e.g., "Key",
-     *     "Value")
-     * @param index the element/entry index (for error message)
-     * @throws IllegalArgumentException if length is negative or exceeds buffer remaining
-     */
-    private static void validateLength(int length, ByteBuffer buffer, String typeName, int index) {
-        if (length < 0) {
-            throw new IllegalArgumentException(
-                    "Invalid negative "
-                            + typeName.toLowerCase()
-                            + " length at element "
-                            + index
-                            + ": "
-                            + length);
-        }
-        if (length > buffer.remaining()) {
-            throw new IllegalArgumentException(
-                    typeName
-                            + " length "
-                            + length
-                            + " exceeds buffer remaining "
-                            + buffer.remaining()
-                            + " at element "
-                            + index);
-        }
-    }
-
-    /**
-     * Deserialize a ByteBuffer containing a serialized map back to Map<?,?>. Format: '%' + count(u32
-     * BE) + repeated [keyLen(u32) + keyBytes + valLen(u32) + valBytes]
-     *
-     * <p>This method includes defense-in-depth validation to protect against malformed buffers from
-     * the native layer (due to bugs or memory corruption).
-     *
-     * @throws IllegalArgumentException if the buffer format is invalid or contains out-of-bounds
-     *     values
-     */
-    private LinkedHashMap<Object, Object> deserializeByteBufferMap(
-            ByteBuffer buffer, boolean expectUtf8) {
-        buffer.order(ByteOrder.BIG_ENDIAN);
-        buffer.rewind();
-
-        // Validate minimum buffer size for marker + count
-        requireBufferBytes(buffer, 5, "map header");
-
-        byte marker = buffer.get();
-        if (marker != '%') {
-            throw new IllegalArgumentException("Expected map marker '%', got: " + (char) marker);
-        }
-
-        int count = buffer.getInt();
-
-        // Validate count is non-negative (primary protection is per-element bounds checking)
-        if (count < 0) {
-            throw new IllegalArgumentException("Invalid negative map count: " + count);
-        }
-
-        // Use reasonable initial capacity to avoid huge upfront allocation
-        // The actual elements will be validated one-by-one against buffer bounds
-        LinkedHashMap<Object, Object> map = new LinkedHashMap<>(Math.min(count, 1024));
-
-        for (int i = 0; i < count; i++) {
-            requireBufferBytes(buffer, 4, "key length at entry " + i);
-            int klen = buffer.getInt();
-            validateLength(klen, buffer, "Key", i);
-
-            Object key;
-            if (expectUtf8) {
-                key = BufferUtils.decodeUtf8(buffer, klen);
-            } else {
-                byte[] kbytes = new byte[klen];
-                buffer.get(kbytes);
-                key = GlideString.gs(kbytes);
-            }
-
-            requireBufferBytes(buffer, 4, "value length at entry " + i);
-            int vlen = buffer.getInt();
-            validateLength(vlen, buffer, "Value", i);
-
-            Object val;
-            if (expectUtf8) {
-                val = BufferUtils.decodeUtf8(buffer, vlen);
-            } else {
-                byte[] vbytes = new byte[vlen];
-                buffer.get(vbytes);
-                val = GlideString.gs(vbytes);
-            }
-            map.put(key, val);
-        }
-        return map;
     }
 
     // Removed blocking command detection - Rust handles all timeout logic
@@ -1018,116 +877,6 @@ public class CommandManager {
 
         // This shouldn't happen if isFinished() is true
         return null;
-    }
-
-    /**
-     * Deserialize a ByteBuffer containing a serialized array back to Object[]. This handles
-     * DirectByteBuffer responses for large data (>16KB). Format uses Redis-like protocol: '*' +
-     * array_len(4 bytes BE) + elements Each element: type_marker + data
-     *
-     * <p>This method includes defense-in-depth validation to protect against malformed buffers from
-     * the native layer (due to bugs or memory corruption).
-     *
-     * @throws IllegalArgumentException if the buffer format is invalid or contains out-of-bounds
-     *     values
-     */
-    private Object[] deserializeByteBufferArray(ByteBuffer buffer, boolean expectUtf8Response) {
-        buffer.order(ByteOrder.BIG_ENDIAN); // Rust uses big-endian
-        buffer.rewind();
-
-        // Validate minimum buffer size for marker + count
-        requireBufferBytes(buffer, 5, "array header");
-
-        // Read array marker ('*')
-        byte marker = buffer.get();
-        if (marker != '*') {
-            throw new IllegalArgumentException("Expected array marker '*', got: " + (char) marker);
-        }
-
-        // Read array element count (4 bytes, big-endian)
-        int count = buffer.getInt();
-
-        // Validate count is non-negative (primary protection is per-element bounds checking)
-        if (count < 0) {
-            throw new IllegalArgumentException("Invalid negative array count: " + count);
-        }
-
-        Object[] result = new Object[count];
-
-        for (int i = 0; i < count; i++) {
-            requireBufferBytes(buffer, 1, "type marker at element " + i);
-
-            // Read element type marker
-            byte typeMarker = buffer.get();
-
-            switch (typeMarker) {
-                case '$': // Bulk string
-                    requireBufferBytes(buffer, 4, "bulk string length at element " + i);
-                    int bulkLen = buffer.getInt();
-                    if (bulkLen == -1) {
-                        result[i] = null;
-                    } else {
-                        validateLength(bulkLen, buffer, "bulk string", i);
-                        if (expectUtf8Response) {
-                            result[i] = BufferUtils.decodeUtf8(buffer, bulkLen);
-                        } else {
-                            byte[] data = new byte[bulkLen];
-                            buffer.get(data);
-                            result[i] = GlideString.gs(data);
-                        }
-                    }
-                    break;
-
-                case '+': // Simple string (includes "OK")
-                    requireBufferBytes(buffer, 4, "simple string length at element " + i);
-                    int simpleLen = buffer.getInt();
-                    validateLength(simpleLen, buffer, "simple string", i);
-                    String simpleString = BufferUtils.decodeUtf8(buffer, simpleLen);
-                    result[i] = simpleString.equalsIgnoreCase("ok") ? "OK" : simpleString;
-                    break;
-
-                case ':': // Integer
-                    requireBufferBytes(buffer, 8, "integer at element " + i);
-                    result[i] = buffer.getLong();
-                    break;
-
-                case ',': // Double
-                    requireBufferBytes(buffer, 8, "double at element " + i);
-                    result[i] = buffer.getDouble();
-                    break;
-
-                case '?': // Boolean
-                    requireBufferBytes(buffer, 1, "boolean at element " + i);
-                    result[i] = buffer.get() != 0;
-                    break;
-
-                case '(': // BigNumber
-                    requireBufferBytes(buffer, 4, "big number length at element " + i);
-                    int bigNumberLen = buffer.getInt();
-                    validateLength(bigNumberLen, buffer, "big number", i);
-                    String bigNumberStr = BufferUtils.decodeUtf8(buffer, bigNumberLen);
-                    result[i] = new BigInteger(bigNumberStr);
-                    break;
-
-                case '#': // Complex type (serialized as string)
-                    requireBufferBytes(buffer, 4, "complex type length at element " + i);
-                    int complexLen = buffer.getInt();
-                    validateLength(complexLen, buffer, "complex type", i);
-                    if (expectUtf8Response) {
-                        result[i] = BufferUtils.decodeUtf8(buffer, complexLen);
-                    } else {
-                        byte[] complexData = new byte[complexLen];
-                        buffer.get(complexData);
-                        result[i] = GlideString.gs(complexData);
-                    }
-                    break;
-
-                default:
-                    throw new IllegalArgumentException("Unknown type marker: " + (char) typeMarker);
-            }
-        }
-
-        return result;
     }
 
     /** Exception handler for future pipeline. */

--- a/java/client/src/main/java/glide/managers/DirectBufferResolver.java
+++ b/java/client/src/main/java/glide/managers/DirectBufferResolver.java
@@ -1,0 +1,271 @@
+/** Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0 */
+package glide.managers;
+
+import glide.api.models.GlideString;
+import glide.utils.BufferUtils;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.LinkedHashMap;
+
+/**
+ * Decodes the zero-copy {@link ByteBuffer} the native layer hands back for responses above the 16 KB
+ * threshold. Every response path shares this one decoder so no two of them can drift apart.
+ */
+public final class DirectBufferResolver {
+
+    private DirectBufferResolver() {}
+
+    /**
+     * Decode a direct buffer into the same object a smaller response would have produced: a {@link
+     * String} or {@link GlideString} for a bulk value, an {@code Object[]} for an array, or a {@link
+     * LinkedHashMap} for a map.
+     */
+    public static Object normalizeDirectBuffer(ByteBuffer buffer, boolean expectUtf8Response) {
+        ByteBuffer dup = buffer.duplicate();
+        dup.order(ByteOrder.BIG_ENDIAN);
+        dup.rewind();
+        if (dup.remaining() == 0) {
+            return expectUtf8Response ? "" : GlideString.gs(new byte[0]);
+        }
+        byte marker = dup.get();
+        dup.rewind();
+        if (marker == '*') {
+            // Serialized array/map (custom wire format)
+            return deserializeByteBufferArray(dup, expectUtf8Response);
+        } else if (marker == '%') {
+            return deserializeByteBufferMap(dup, expectUtf8Response);
+        }
+        // Bulk string bytes
+        if (expectUtf8Response) {
+            // Decode UTF-8 directly from buffer
+            return BufferUtils.decodeUtf8(dup);
+        } else {
+            byte[] bytes = new byte[dup.remaining()];
+            dup.get(bytes);
+            return GlideString.gs(bytes);
+        }
+    }
+
+    /**
+     * Validate that the buffer has at least the required number of bytes remaining.
+     *
+     * @param buffer the buffer to check
+     * @param required the minimum number of bytes required
+     * @param context description of what is being read (for error message)
+     * @throws IllegalArgumentException if buffer has insufficient bytes
+     */
+    private static void requireBufferBytes(ByteBuffer buffer, int required, String context) {
+        if (buffer.remaining() < required) {
+            throw new IllegalArgumentException(
+                    "Buffer too small for " + context + ": " + buffer.remaining() + " bytes");
+        }
+    }
+
+    /**
+     * Validate a length field read from the buffer.
+     *
+     * @param length the length value to validate
+     * @param buffer the buffer to check remaining bytes against
+     * @param typeName description of the data type (for error message), capitalized (e.g., "Key",
+     *     "Value")
+     * @param index the element/entry index (for error message)
+     * @throws IllegalArgumentException if length is negative or exceeds buffer remaining
+     */
+    private static void validateLength(int length, ByteBuffer buffer, String typeName, int index) {
+        if (length < 0) {
+            throw new IllegalArgumentException(
+                    "Invalid negative "
+                            + typeName.toLowerCase()
+                            + " length at element "
+                            + index
+                            + ": "
+                            + length);
+        }
+        if (length > buffer.remaining()) {
+            throw new IllegalArgumentException(
+                    typeName
+                            + " length "
+                            + length
+                            + " exceeds buffer remaining "
+                            + buffer.remaining()
+                            + " at element "
+                            + index);
+        }
+    }
+
+    /**
+     * Deserialize a ByteBuffer containing a serialized map back to Map<?,?>. Format: '%' + count(u32
+     * BE) + repeated [keyLen(u32) + keyBytes + valLen(u32) + valBytes]
+     *
+     * <p>This method includes defense-in-depth validation to protect against malformed buffers from
+     * the native layer (due to bugs or memory corruption).
+     *
+     * @throws IllegalArgumentException if the buffer format is invalid or contains out-of-bounds
+     *     values
+     */
+    public static LinkedHashMap<Object, Object> deserializeByteBufferMap(
+            ByteBuffer buffer, boolean expectUtf8) {
+        buffer.order(ByteOrder.BIG_ENDIAN);
+        buffer.rewind();
+
+        // Validate minimum buffer size for marker + count
+        requireBufferBytes(buffer, 5, "map header");
+
+        byte marker = buffer.get();
+        if (marker != '%') {
+            throw new IllegalArgumentException("Expected map marker '%', got: " + (char) marker);
+        }
+
+        int count = buffer.getInt();
+
+        // Validate count is non-negative (primary protection is per-element bounds checking)
+        if (count < 0) {
+            throw new IllegalArgumentException("Invalid negative map count: " + count);
+        }
+
+        // Use reasonable initial capacity to avoid huge upfront allocation
+        // The actual elements will be validated one-by-one against buffer bounds
+        LinkedHashMap<Object, Object> map = new LinkedHashMap<>(Math.min(count, 1024));
+
+        for (int i = 0; i < count; i++) {
+            requireBufferBytes(buffer, 4, "key length at entry " + i);
+            int klen = buffer.getInt();
+            validateLength(klen, buffer, "Key", i);
+
+            Object key;
+            if (expectUtf8) {
+                key = BufferUtils.decodeUtf8(buffer, klen);
+            } else {
+                byte[] kbytes = new byte[klen];
+                buffer.get(kbytes);
+                key = GlideString.gs(kbytes);
+            }
+
+            requireBufferBytes(buffer, 4, "value length at entry " + i);
+            int vlen = buffer.getInt();
+            validateLength(vlen, buffer, "Value", i);
+
+            Object val;
+            if (expectUtf8) {
+                val = BufferUtils.decodeUtf8(buffer, vlen);
+            } else {
+                byte[] vbytes = new byte[vlen];
+                buffer.get(vbytes);
+                val = GlideString.gs(vbytes);
+            }
+            map.put(key, val);
+        }
+        return map;
+    }
+
+    /**
+     * Deserialize a ByteBuffer containing a serialized array back to Object[]. This handles
+     * DirectByteBuffer responses for large data (>16KB). Format uses Redis-like protocol: '*' +
+     * array_len(4 bytes BE) + elements Each element: type_marker + data
+     *
+     * <p>This method includes defense-in-depth validation to protect against malformed buffers from
+     * the native layer (due to bugs or memory corruption).
+     *
+     * @throws IllegalArgumentException if the buffer format is invalid or contains out-of-bounds
+     *     values
+     */
+    public static Object[] deserializeByteBufferArray(ByteBuffer buffer, boolean expectUtf8Response) {
+        buffer.order(ByteOrder.BIG_ENDIAN); // Rust uses big-endian
+        buffer.rewind();
+
+        // Validate minimum buffer size for marker + count
+        requireBufferBytes(buffer, 5, "array header");
+
+        // Read array marker ('*')
+        byte marker = buffer.get();
+        if (marker != '*') {
+            throw new IllegalArgumentException("Expected array marker '*', got: " + (char) marker);
+        }
+
+        // Read array element count (4 bytes, big-endian)
+        int count = buffer.getInt();
+
+        // Validate count is non-negative (primary protection is per-element bounds checking)
+        if (count < 0) {
+            throw new IllegalArgumentException("Invalid negative array count: " + count);
+        }
+
+        Object[] result = new Object[count];
+
+        for (int i = 0; i < count; i++) {
+            requireBufferBytes(buffer, 1, "type marker at element " + i);
+
+            // Read element type marker
+            byte typeMarker = buffer.get();
+
+            switch (typeMarker) {
+                case '$': // Bulk string
+                    requireBufferBytes(buffer, 4, "bulk string length at element " + i);
+                    int bulkLen = buffer.getInt();
+                    if (bulkLen == -1) {
+                        result[i] = null;
+                    } else {
+                        validateLength(bulkLen, buffer, "bulk string", i);
+                        if (expectUtf8Response) {
+                            result[i] = BufferUtils.decodeUtf8(buffer, bulkLen);
+                        } else {
+                            byte[] data = new byte[bulkLen];
+                            buffer.get(data);
+                            result[i] = GlideString.gs(data);
+                        }
+                    }
+                    break;
+
+                case '+': // Simple string (includes "OK")
+                    requireBufferBytes(buffer, 4, "simple string length at element " + i);
+                    int simpleLen = buffer.getInt();
+                    validateLength(simpleLen, buffer, "simple string", i);
+                    String simpleString = BufferUtils.decodeUtf8(buffer, simpleLen);
+                    result[i] = simpleString.equalsIgnoreCase("ok") ? "OK" : simpleString;
+                    break;
+
+                case ':': // Integer
+                    requireBufferBytes(buffer, 8, "integer at element " + i);
+                    result[i] = buffer.getLong();
+                    break;
+
+                case ',': // Double
+                    requireBufferBytes(buffer, 8, "double at element " + i);
+                    result[i] = buffer.getDouble();
+                    break;
+
+                case '?': // Boolean
+                    requireBufferBytes(buffer, 1, "boolean at element " + i);
+                    result[i] = buffer.get() != 0;
+                    break;
+
+                case '(': // BigNumber
+                    requireBufferBytes(buffer, 4, "big number length at element " + i);
+                    int bigNumberLen = buffer.getInt();
+                    validateLength(bigNumberLen, buffer, "big number", i);
+                    String bigNumberStr = BufferUtils.decodeUtf8(buffer, bigNumberLen);
+                    result[i] = new BigInteger(bigNumberStr);
+                    break;
+
+                case '#': // Complex type (serialized as string)
+                    requireBufferBytes(buffer, 4, "complex type length at element " + i);
+                    int complexLen = buffer.getInt();
+                    validateLength(complexLen, buffer, "complex type", i);
+                    if (expectUtf8Response) {
+                        result[i] = BufferUtils.decodeUtf8(buffer, complexLen);
+                    } else {
+                        byte[] complexData = new byte[complexLen];
+                        buffer.get(complexData);
+                        result[i] = GlideString.gs(complexData);
+                    }
+                    break;
+
+                default:
+                    throw new IllegalArgumentException("Unknown type marker: " + (char) typeMarker);
+            }
+        }
+
+        return result;
+    }
+}

--- a/java/client/src/main/java/glide/managers/DirectBufferResolver.java
+++ b/java/client/src/main/java/glide/managers/DirectBufferResolver.java
@@ -9,8 +9,8 @@ import java.nio.ByteOrder;
 import java.util.LinkedHashMap;
 
 /**
- * Decodes the zero-copy {@link ByteBuffer} the native layer hands back for responses above the 16 KB
- * threshold. Every response path shares this one decoder so no two of them can drift apart.
+ * Decodes the zero-copy {@link ByteBuffer} the native layer hands back for responses above the 16
+ * KB threshold. Every response path shares this one decoder so no two of them can drift apart.
  */
 public final class DirectBufferResolver {
 

--- a/java/client/src/test/java/glide/managers/DirectBufferResolverTest.java
+++ b/java/client/src/test/java/glide/managers/DirectBufferResolverTest.java
@@ -5,9 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
-import glide.internal.GlideCoreClient;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
@@ -15,17 +13,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class CommandManagerDirectBufferTest {
-
-    private CommandManager commandManager;
-
-    @BeforeEach
-    void setUp() {
-        commandManager = new CommandManager(mock(GlideCoreClient.class));
-    }
+public class DirectBufferResolverTest {
 
     @Test
     void deserializeByteBufferArray_handlesBooleanDoubleAndBigNumberMarkers() throws Exception {
@@ -268,20 +258,19 @@ public class CommandManagerDirectBufferTest {
     private Object[] deserializeByteBufferArray(ByteBuffer buffer, boolean expectUtf8Response)
             throws Exception {
         Method method =
-                CommandManager.class.getDeclaredMethod(
+                DirectBufferResolver.class.getDeclaredMethod(
                         "deserializeByteBufferArray", ByteBuffer.class, boolean.class);
         method.setAccessible(true);
-        return (Object[]) method.invoke(commandManager, buffer, expectUtf8Response);
+        return (Object[]) method.invoke(null, buffer, expectUtf8Response);
     }
 
     @SuppressWarnings("unchecked")
     private LinkedHashMap<Object, Object> deserializeByteBufferMap(
             ByteBuffer buffer, boolean expectUtf8Response) throws Exception {
         Method method =
-                CommandManager.class.getDeclaredMethod(
+                DirectBufferResolver.class.getDeclaredMethod(
                         "deserializeByteBufferMap", ByteBuffer.class, boolean.class);
         method.setAccessible(true);
-        return (LinkedHashMap<Object, Object>)
-                method.invoke(commandManager, buffer, expectUtf8Response);
+        return (LinkedHashMap<Object, Object>) method.invoke(null, buffer, expectUtf8Response);
     }
 }

--- a/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
@@ -15,6 +15,8 @@ import glide.api.models.pool.ClientPoolConfig;
 import glide.api.models.pool.PooledGlideClient;
 import glide.api.models.scope.IsolatedScope;
 import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -85,6 +87,134 @@ public class PooledClientScopeIntegrationTest {
             assertTrue(scope.isReleased());
 
             pooled.unwrap().del(new String[] {key}).get(5, TimeUnit.SECONDS);
+        } finally {
+            pooled.close();
+            pool.close();
+        }
+    }
+
+    /** Build an ASCII string of exactly {@code size} bytes so byte length equals character length. */
+    private static String asciiValue(int size) {
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            sb.append((char) ('a' + (i % 26)));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * A value larger than the native layer's 16 KB direct-buffer threshold used to come back through
+     * a scope as the buffer's debug string. Read across that boundary and confirm the scope returns
+     * the whole value, matching a normal client.
+     */
+    @Test
+    public void testScopedConnectionReadsValuesAcrossDirectBufferThreshold() throws Exception {
+        ClientPool pool = ClientPool.create(standaloneConfig());
+        waitForPoolReady(pool, 1);
+
+        PooledGlideClient pooled = pool.acquire().get(10, TimeUnit.SECONDS);
+        try {
+            IsolatedScope scope =
+                    pooled.unwrap().scopedConnection(Duration.ofSeconds(10)).get(10, TimeUnit.SECONDS);
+            try {
+                int[] sizes = {16 * 1024, 16 * 1024 + 1, 1024 * 1024};
+                for (int size : sizes) {
+                    String key = "scope-large-" + size + "-" + UUID.randomUUID();
+                    String value = asciiValue(size);
+                    pooled.set(key, value).get(5, TimeUnit.SECONDS);
+
+                    String viaScope = scope.get(key).get(5, TimeUnit.SECONDS);
+                    String viaClient = pooled.get(key).get(5, TimeUnit.SECONDS);
+
+                    assertEquals(size, viaScope.length(), "scope truncated value of size " + size);
+                    assertEquals(viaClient, viaScope, "scope value differs from client at size " + size);
+
+                    pooled.unwrap().del(new String[] {key}).get(5, TimeUnit.SECONDS);
+                }
+            } finally {
+                scope.close();
+            }
+        } finally {
+            pooled.close();
+            pool.close();
+        }
+    }
+
+    /**
+     * Large array and map replies (LRANGE, MGET, HGETALL) exceed the direct-buffer threshold too.
+     * Read them through a scope and confirm every element matches a normal client, not just strings.
+     */
+    @Test
+    public void testScopedConnectionDecodesLargeAggregates() throws Exception {
+        ClientPool pool = ClientPool.create(standaloneConfig());
+        waitForPoolReady(pool, 1);
+
+        PooledGlideClient pooled = pool.acquire().get(10, TimeUnit.SECONDS);
+        try {
+            IsolatedScope scope =
+                    pooled.unwrap().scopedConnection(Duration.ofSeconds(10)).get(10, TimeUnit.SECONDS);
+            try {
+                String suffix = UUID.randomUUID().toString();
+
+                // LRANGE: a list whose serialized reply is well past the 16 KB threshold.
+                String listKey = "scope-list-" + suffix;
+                String[] elements = new String[1000];
+                for (int i = 0; i < elements.length; i++) {
+                    elements[i] = "list-element-" + i + "-" + asciiValue(64);
+                }
+                pooled.unwrap().rpush(listKey, elements).get(5, TimeUnit.SECONDS);
+
+                Object viaScopeList = scope.command("LRANGE", listKey, "0", "-1").get(5, TimeUnit.SECONDS);
+                String[] viaClientList = pooled.unwrap().lrange(listKey, 0, -1).get(5, TimeUnit.SECONDS);
+                assertTrue(viaScopeList instanceof Object[], "LRANGE must decode to an array");
+                Object[] scopeList = (Object[]) viaScopeList;
+                assertEquals(viaClientList.length, scopeList.length, "LRANGE length mismatch");
+                for (int i = 0; i < scopeList.length; i++) {
+                    assertEquals(viaClientList[i], scopeList[i], "LRANGE element " + i + " mismatch");
+                }
+
+                // MGET: several large values in one reply.
+                String[] keys = new String[20];
+                String[] values = new String[keys.length];
+                for (int i = 0; i < keys.length; i++) {
+                    keys[i] = "scope-mget-" + i + "-" + suffix;
+                    values[i] = asciiValue(2048);
+                    pooled.set(keys[i], values[i]).get(5, TimeUnit.SECONDS);
+                }
+                Object viaScopeMget =
+                        scope.command("MGET", keys).get(5, TimeUnit.SECONDS);
+                String[] viaClientMget = pooled.unwrap().mget(keys).get(5, TimeUnit.SECONDS);
+                assertTrue(viaScopeMget instanceof Object[], "MGET must decode to an array");
+                Object[] scopeMget = (Object[]) viaScopeMget;
+                assertEquals(viaClientMget.length, scopeMget.length, "MGET length mismatch");
+                for (int i = 0; i < scopeMget.length; i++) {
+                    assertEquals(viaClientMget[i], scopeMget[i], "MGET element " + i + " mismatch");
+                }
+
+                // HGETALL: a hash whose serialized map reply is past the threshold.
+                String hashKey = "scope-hash-" + suffix;
+                LinkedHashMap<String, String> fields = new LinkedHashMap<>();
+                for (int i = 0; i < 500; i++) {
+                    fields.put("field-" + i, "value-" + i + "-" + asciiValue(64));
+                }
+                pooled.unwrap().hset(hashKey, fields).get(5, TimeUnit.SECONDS);
+
+                Object viaScopeHash = scope.command("HGETALL", hashKey).get(5, TimeUnit.SECONDS);
+                Map<String, String> viaClientHash =
+                        pooled.unwrap().hgetall(hashKey).get(5, TimeUnit.SECONDS);
+                assertTrue(viaScopeHash instanceof Map, "HGETALL must decode to a map");
+                Map<?, ?> scopeHash = (Map<?, ?>) viaScopeHash;
+                assertEquals(viaClientHash.size(), scopeHash.size(), "HGETALL size mismatch");
+                for (Map.Entry<String, String> entry : viaClientHash.entrySet()) {
+                    assertEquals(
+                            entry.getValue(), scopeHash.get(entry.getKey()), "HGETALL field " + entry.getKey());
+                }
+
+                pooled.unwrap().del(new String[] {listKey, hashKey}).get(5, TimeUnit.SECONDS);
+                pooled.unwrap().del(keys).get(5, TimeUnit.SECONDS);
+            } finally {
+                scope.close();
+            }
         } finally {
             pooled.close();
             pool.close();

--- a/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
+++ b/java/integTest/src/test/java/glide/pool/PooledClientScopeIntegrationTest.java
@@ -181,8 +181,7 @@ public class PooledClientScopeIntegrationTest {
                     values[i] = asciiValue(2048);
                     pooled.set(keys[i], values[i]).get(5, TimeUnit.SECONDS);
                 }
-                Object viaScopeMget =
-                        scope.command("MGET", keys).get(5, TimeUnit.SECONDS);
+                Object viaScopeMget = scope.command("MGET", keys).get(5, TimeUnit.SECONDS);
                 String[] viaClientMget = pooled.unwrap().mget(keys).get(5, TimeUnit.SECONDS);
                 assertTrue(viaScopeMget instanceof Object[], "MGET must decode to an array");
                 Object[] scopeMget = (Object[]) viaScopeMget;


### PR DESCRIPTION
### Summary

Reading a value through a Java scoped connection (`client.scopedConnection()`, from the experimental client pool) now returns the complete value regardless of its size. Responses above 16 KB, which the native layer delivers as a zero-copy direct buffer, are decoded through the same logic the standard client uses, so a scoped read matches a standard `get` byte for byte.

### Issue link

This Pull Request is linked to issue: [Java: IsolatedScope truncates values larger than 16 KB on read](https://github.com/valkey-io/valkey-glide/issues/6893)
Closes #6893

### Features / Behaviour Changes

- Scoped reads of large bulk values (over the 16 KB direct-buffer threshold) return the full value, identical to a standard client. Values at or below the threshold are unchanged.
- Large aggregate replies (for example `LRANGE`, `MGET`, `HGETALL`) decode to their real types through the scope.
- New `IsolatedScope.command(String, String...)` returns the decoded response object (`String`, `Object[]`, or `Map`). The existing string-returning helpers keep their signatures.

### Implementation

- Added `glide.managers.DirectBufferResolver`, a single decoder for the direct buffer the native layer returns for large responses. It turns a bulk value into a `String` or `GlideString`, an array into an `Object[]`, and a map into a `LinkedHashMap`, and validates buffer bounds defensively.
- `CommandManager` delegates its direct-buffer normalization to `DirectBufferResolver`, so the standard client and scoped connections share one decoder rather than maintaining separate copies.
- `IsolatedScope` resolves every response through `DirectBufferResolver`: values at or below the threshold arrive already decoded and pass through untouched, while larger values are decoded from the direct buffer. `cmd`, `executeCommand`, and the typed helpers such as `get` keep returning `String`; the new `command` method exposes the decoded object for callers that need arrays or maps.

### Limitations

- The string-returning helpers (`cmd`, `executeCommand`, and the typed methods) render non-string replies with their string form. Use `command(String, String...)` to obtain arrays and maps as their real types.

### Testing

- Integration tests for scoped connections: reading across the 16 KB boundary (16 KB, 16 KB + 1, and 1 MB) returns the full value byte for byte and matches a standard client, and large `LRANGE`, `MGET`, and `HGETALL` replies decode element for element to match a standard client.
- Unit tests for `DirectBufferResolver` covering array and map deserialization and malformed-buffer validation.
- The existing scoped-connection integration test continues to pass.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [ ] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
