### PR TITLE
ci(rust): add `lint` job for Rust client and drop `rustfmt.toml`

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -2,6 +2,7 @@ name: Install protoc
 description: Install protobuf compiler (protoc)
 
 inputs:
+    # GitHub token allows setup-protoc action to avoid rate limiting.
     github-token:
         description: "GitHub token for downloading protoc release"
         required: true

--- a/.github/workflows/lint-rust/action.yml
+++ b/.github/workflows/lint-rust/action.yml
@@ -1,14 +1,15 @@
 name: Lint rust
+description: "Run linting for a Rust crate"
 
 inputs:
     cargo-toml-folder:
         description: "folder that contains the target Cargo.toml file"
         required: true
-        type: string
+
+    # GitHub token allows install-protoc action to avoid rate limiting.
     github-token:
         description: "github token"
-        required: false
-        type: string
+        required: true
 
 runs:
     using: "composite"

--- a/.github/workflows/rust-client.yml
+++ b/.github/workflows/rust-client.yml
@@ -13,19 +13,23 @@ on:
             - rust/**
             - glide-core/**
             - logger_core/**
+            - deny.toml
             - utils/cluster_manager.py
             - .github/workflows/rust-client.yml
             - .github/actions/install-shared-dependencies/action.yml
             - .github/actions/install-engine/action.yml
+            - .github/workflows/lint-rust/action.yml
     pull_request:
         paths:
             - rust/**
             - glide-core/**
             - logger_core/**
+            - deny.toml
             - utils/cluster_manager.py
             - .github/workflows/rust-client.yml
             - .github/actions/install-shared-dependencies/action.yml
             - .github/actions/install-engine/action.yml
+            - .github/workflows/lint-rust/action.yml
     workflow_dispatch:
 
 concurrency:
@@ -36,6 +40,20 @@ env:
     CARGO_TERM_COLOR: always
 
 jobs:
+    lint:
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                  persist-credentials: false
+
+            - uses: ./.github/workflows/lint-rust
+              with:
+                  cargo-toml-folder: rust
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+              name: lint rust client
+
     tests:
         runs-on: ubuntu-latest
         timeout-minutes: 35
@@ -55,26 +73,3 @@ jobs:
             - name: Run rust client tests
               working-directory: ./rust
               run: cargo test
-
-    # TODO #6519: This standalone deny job runs the client's dependency closure
-    # against the shared root deny.toml. It is expected to be folded into the
-    # shared Rust lint tooling (see .github/workflows/lint-rust) in future work.
-    deny:
-        runs-on: ubuntu-latest
-        timeout-minutes: 20
-        steps:
-            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-              with:
-                  persist-credentials: false
-
-            - name: Install Rust toolchain
-              uses: ./.github/actions/install-rust
-              with:
-                  target: x86_64-unknown-linux-gnu
-
-            - name: Install cargo-deny
-              run: cargo install --locked cargo-deny
-
-            - name: cargo deny check
-              working-directory: ./rust
-              run: cargo deny --config ${GITHUB_WORKSPACE}/deny.toml check

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,3 +1,0 @@
-# Formatting config. Kept minimal so `rustfmt` (standalone) matches `cargo fmt`
-# defaults for this crate's edition; run `cargo fmt` to apply.
-edition = "2024"


### PR DESCRIPTION
### Summary

Adds a `lint` job for the Rust client (`rust/`). Re-uses the existing `lint-rust` action.
Also removes unused `rust/rustfmt.toml` (`cargo fmt` gets edition from `Cargo.toml`).

### Issue link

Closes #6867
Closes #6868

### Implementation

- Add new `lint` job that uses `lint-rust` action to `rust-client.yml`.
- Removed the standalone `deny` job from `rust-client.yml`.
- Added `lint-rust` action and `deny.toml` to the workflow triggers.

### Limitations

:white_circle: None.

### Testing

Verify that `lint-rust` action runs on `rust` crate.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] ~~This Pull Request is related to one issue.~~ Resolves two issues.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] ~~CHANGELOG.md and documentation files are updated.~~ :white_circle: N/A — CI-only change.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] ~~Make sure to update the documentation in the valkey-glide-docs repository if necessary.~~ :white_circle: N/A.
