### PR TITLE
feat(rust): use redis Expiry/SetExpiry for HGETEX/HSETEX

### DIFF
--- a/glide-core/redis-rs/redis/src/commands/mod.rs
+++ b/glide-core/redis-rs/redis/src/commands/mod.rs
@@ -154,15 +154,7 @@ implement_commands! {
 
     /// Get the value of a key and set expiration
     fn get_ex<K: ToRedisArgs>(key: K, expire_at: Expiry) {
-        let (option, time_arg) = match expire_at {
-            Expiry::EX(sec) => ("EX", Some(sec)),
-            Expiry::PX(ms) => ("PX", Some(ms)),
-            Expiry::EXAT(timestamp_sec) => ("EXAT", Some(timestamp_sec)),
-            Expiry::PXAT(timestamp_ms) => ("PXAT", Some(timestamp_ms)),
-            Expiry::PERSIST => ("PERSIST", None),
-        };
-
-        cmd("GETEX").arg(key).arg(option).arg(time_arg)
+        cmd("GETEX").arg(key).arg(expire_at)
     }
 
     /// Get the value of a key and delete it
@@ -1150,27 +1142,7 @@ impl ToRedisArgs for SetOptions {
             out.write_arg(b"GET");
         }
         if let Some(ref expiration) = self.expiration {
-            match expiration {
-                SetExpiry::EX(secs) => {
-                    out.write_arg(b"EX");
-                    out.write_arg(format!("{secs}").as_bytes());
-                }
-                SetExpiry::PX(millis) => {
-                    out.write_arg(b"PX");
-                    out.write_arg(format!("{millis}").as_bytes());
-                }
-                SetExpiry::EXAT(unix_time) => {
-                    out.write_arg(b"EXAT");
-                    out.write_arg(format!("{unix_time}").as_bytes());
-                }
-                SetExpiry::PXAT(unix_time) => {
-                    out.write_arg(b"PXAT");
-                    out.write_arg(format!("{unix_time}").as_bytes());
-                }
-                SetExpiry::KEEPTTL => {
-                    out.write_arg(b"KEEPTTL");
-                }
-            }
+            expiration.write_redis_args(out);
         }
     }
 }

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -45,6 +45,39 @@ pub enum Expiry {
     PERSIST,
 }
 
+impl ToRedisArgs for Expiry {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            Expiry::EX(sec) => {
+                out.write_arg(b"EX");
+                out.write_arg_fmt(sec);
+            }
+            Expiry::PX(ms) => {
+                out.write_arg(b"PX");
+                out.write_arg_fmt(ms);
+            }
+            Expiry::EXAT(timestamp_sec) => {
+                out.write_arg(b"EXAT");
+                out.write_arg_fmt(timestamp_sec);
+            }
+            Expiry::PXAT(timestamp_ms) => {
+                out.write_arg(b"PXAT");
+                out.write_arg_fmt(timestamp_ms);
+            }
+            Expiry::PERSIST => {
+                out.write_arg(b"PERSIST");
+            }
+        }
+    }
+
+    fn is_single_arg(&self) -> bool {
+        false
+    }
+}
+
 /// Helper enum that is used to define expiry time for SET command
 #[derive(Clone, Copy)]
 pub enum SetExpiry {
@@ -58,6 +91,39 @@ pub enum SetExpiry {
     PXAT(usize),
     /// KEEPTTL -- Retain the time to live associated with the key.
     KEEPTTL,
+}
+
+impl ToRedisArgs for SetExpiry {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        match self {
+            SetExpiry::EX(secs) => {
+                out.write_arg(b"EX");
+                out.write_arg_fmt(secs);
+            }
+            SetExpiry::PX(millis) => {
+                out.write_arg(b"PX");
+                out.write_arg_fmt(millis);
+            }
+            SetExpiry::EXAT(unix_time) => {
+                out.write_arg(b"EXAT");
+                out.write_arg_fmt(unix_time);
+            }
+            SetExpiry::PXAT(unix_time) => {
+                out.write_arg(b"PXAT");
+                out.write_arg_fmt(unix_time);
+            }
+            SetExpiry::KEEPTTL => {
+                out.write_arg(b"KEEPTTL");
+            }
+        }
+    }
+
+    fn is_single_arg(&self) -> bool {
+        false
+    }
 }
 
 /// Helper enum that is used to define existence checks

--- a/glide-core/redis-rs/redis/src/types.rs
+++ b/glide-core/redis-rs/redis/src/types.rs
@@ -74,7 +74,7 @@ impl ToRedisArgs for Expiry {
     }
 
     fn is_single_arg(&self) -> bool {
-        false
+        matches!(self, Expiry::PERSIST)
     }
 }
 
@@ -122,7 +122,7 @@ impl ToRedisArgs for SetExpiry {
     }
 
     fn is_single_arg(&self) -> bool {
-        false
+        matches!(self, SetExpiry::KEEPTTL)
     }
 }
 

--- a/glide-core/redis-rs/redis/tests/test_types.rs
+++ b/glide-core/redis-rs/redis/tests/test_types.rs
@@ -2,7 +2,7 @@ mod support;
 
 #[cfg(test)]
 mod types {
-    use redis::{FromRedisValue, ToRedisArgs, Value};
+    use redis::{Expiry, FromRedisValue, SetExpiry, ToRedisArgs, Value};
     #[test]
     fn test_is_single_arg() {
         let sslice: &[_] = &["foo"][..];
@@ -20,6 +20,24 @@ mod types {
 
         assert!(!twobytesslice.is_single_arg());
         assert!(!twobytesvec.is_single_arg());
+    }
+
+    #[test]
+    fn test_expiry_is_single_arg() {
+        assert!(Expiry::PERSIST.is_single_arg());
+        assert!(!Expiry::EX(1).is_single_arg());
+        assert!(!Expiry::PX(1).is_single_arg());
+        assert!(!Expiry::EXAT(1).is_single_arg());
+        assert!(!Expiry::PXAT(1).is_single_arg());
+    }
+
+    #[test]
+    fn test_set_expiry_is_single_arg() {
+        assert!(SetExpiry::KEEPTTL.is_single_arg());
+        assert!(!SetExpiry::EX(1).is_single_arg());
+        assert!(!SetExpiry::PX(1).is_single_arg());
+        assert!(!SetExpiry::EXAT(1).is_single_arg());
+        assert!(!SetExpiry::PXAT(1).is_single_arg());
     }
 
     /// The `FromRedisValue` trait provides two methods for parsing:

--- a/glide-core/redis-rs/redis/tests/test_types.rs
+++ b/glide-core/redis-rs/redis/tests/test_types.rs
@@ -22,24 +22,6 @@ mod types {
         assert!(!twobytesvec.is_single_arg());
     }
 
-    #[test]
-    fn test_expiry_is_single_arg() {
-        assert!(Expiry::PERSIST.is_single_arg());
-        assert!(!Expiry::EX(1).is_single_arg());
-        assert!(!Expiry::PX(1).is_single_arg());
-        assert!(!Expiry::EXAT(1).is_single_arg());
-        assert!(!Expiry::PXAT(1).is_single_arg());
-    }
-
-    #[test]
-    fn test_set_expiry_is_single_arg() {
-        assert!(SetExpiry::KEEPTTL.is_single_arg());
-        assert!(!SetExpiry::EX(1).is_single_arg());
-        assert!(!SetExpiry::PX(1).is_single_arg());
-        assert!(!SetExpiry::EXAT(1).is_single_arg());
-        assert!(!SetExpiry::PXAT(1).is_single_arg());
-    }
-
     /// The `FromRedisValue` trait provides two methods for parsing:
     /// - `fn from_redis_value(&Value) -> Result<T, RedisError>`
     /// - `fn from_owned_redis_value(Value) -> Result<T, RedisError>`
@@ -588,5 +570,68 @@ mod types {
                 ])
             )
         }
+    }
+
+    #[test]
+    fn test_expiry_is_single_arg() {
+        assert!(Expiry::PERSIST.is_single_arg());
+        assert!(!Expiry::EX(1).is_single_arg());
+        assert!(!Expiry::PX(1).is_single_arg());
+        assert!(!Expiry::EXAT(1).is_single_arg());
+        assert!(!Expiry::PXAT(1).is_single_arg());
+    }
+
+    #[test]
+    fn test_set_expiry_is_single_arg() {
+        assert!(SetExpiry::KEEPTTL.is_single_arg());
+        assert!(!SetExpiry::EX(1).is_single_arg());
+        assert!(!SetExpiry::PX(1).is_single_arg());
+        assert!(!SetExpiry::EXAT(1).is_single_arg());
+        assert!(!SetExpiry::PXAT(1).is_single_arg());
+    }
+
+    #[test]
+    fn test_expiry_to_redis_args() {
+        assert_eq!(
+            Expiry::EX(60).to_redis_args(),
+            vec![b"EX".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            Expiry::PX(60).to_redis_args(),
+            vec![b"PX".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            Expiry::EXAT(60).to_redis_args(),
+            vec![b"EXAT".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            Expiry::PXAT(60).to_redis_args(),
+            vec![b"PXAT".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(Expiry::PERSIST.to_redis_args(), vec![b"PERSIST".to_vec()]);
+    }
+
+    #[test]
+    fn test_set_expiry_to_redis_args() {
+        assert_eq!(
+            SetExpiry::EX(60).to_redis_args(),
+            vec![b"EX".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            SetExpiry::PX(60).to_redis_args(),
+            vec![b"PX".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            SetExpiry::EXAT(60).to_redis_args(),
+            vec![b"EXAT".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            SetExpiry::PXAT(60).to_redis_args(),
+            vec![b"PXAT".to_vec(), b"60".to_vec()]
+        );
+        assert_eq!(
+            SetExpiry::KEEPTTL.to_redis_args(),
+            vec![b"KEEPTTL".to_vec()]
+        );
     }
 }

--- a/rust/src/commands/hash.rs
+++ b/rust/src/commands/hash.rs
@@ -1,13 +1,13 @@
 // Copyright Valkey GLIDE Project Contributors - SPDX Identifier: Apache-2.0
 //! Hash commands. Mirrors Python's hash command surface.
 
-use crate::commands::options::{ExpireOptions, ExpirySet, HashFieldConditionalChange};
+use crate::commands::options::{ExpireOptions, HashFieldConditionalChange};
 use crate::error::Result;
 use crate::executor::CommandExecutor;
 use crate::value;
 use async_trait::async_trait;
 use bytes::Bytes;
-use redis::{Cmd, ToRedisArgs};
+use redis::{Cmd, Expiry, SetExpiry, ToRedisArgs};
 
 /// Hash commands (`HSET`, `HGET`, `HGETALL`, `HDEL`, ...).
 #[async_trait]
@@ -219,21 +219,18 @@ pub trait HashCommands: CommandExecutor {
         collect_i64(self.execute_command(cmd, None).await?)
     }
 
-    // TODO #6934: hgetex and hsetex share ExpirySet, which allows options each
-    // command rejects at runtime (HGETEX + KEEPTTL, HSETEX + PERSIST). Split
-    // into distinct expiry types so invalid combinations are unrepresentable.
     /// Get the values of hash fields, optionally changing their expiry
     /// (`HGETEX`).
     async fn hgetex<K: ToRedisArgs + Send, F: ToRedisArgs + Send + Sync>(
         &self,
         key: K,
         fields: &[F],
-        expiry: Option<ExpirySet>,
+        expiry: Option<Expiry>,
     ) -> Result<Vec<Option<Bytes>>> {
         let mut cmd = Cmd::new();
         cmd.arg("HGETEX").arg(key);
         if let Some(e) = expiry {
-            e.add_to(&mut cmd);
+            cmd.arg(e);
         }
         cmd.arg("FIELDS").arg(fields.len());
         for f in fields {
@@ -253,7 +250,7 @@ pub trait HashCommands: CommandExecutor {
         key: K,
         field_values: &[(F, V)],
         condition: Option<HashFieldConditionalChange>,
-        expiry: Option<ExpirySet>,
+        expiry: Option<SetExpiry>,
     ) -> Result<i64>
     where
         K: ToRedisArgs + Send + Sync,
@@ -266,7 +263,7 @@ pub trait HashCommands: CommandExecutor {
             cmd.arg(c.as_arg());
         }
         if let Some(e) = expiry {
-            e.add_to(&mut cmd);
+            cmd.arg(e);
         }
         cmd.arg("FIELDS").arg(field_values.len());
         for (f, v) in field_values {

--- a/rust/src/commands/options.rs
+++ b/rust/src/commands/options.rs
@@ -26,50 +26,6 @@ impl ConditionalChange {
     }
 }
 
-/// Expiry for `SET` / `GETEX`.
-///
-/// Mirrors Python `ExpirySet` / `ExpiryType`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExpirySet {
-    /// Set expiry, in seconds (`EX`).
-    Seconds(u64),
-    /// Set expiry, in milliseconds (`PX`).
-    Milliseconds(u64),
-    /// Set expiry at a Unix timestamp, in seconds (`EXAT`).
-    UnixSeconds(u64),
-    /// Set expiry at a Unix timestamp, in milliseconds (`PXAT`).
-    UnixMilliseconds(u64),
-    /// Retain the existing TTL (`KEEPTTL`).
-    KeepExisting,
-    /// Remove any TTL (`PERSIST`, used by `GETEX`).
-    Persist,
-}
-
-impl ExpirySet {
-    pub(crate) fn add_to(&self, cmd: &mut Cmd) {
-        match self {
-            ExpirySet::Seconds(v) => {
-                cmd.arg("EX").arg(v);
-            }
-            ExpirySet::Milliseconds(v) => {
-                cmd.arg("PX").arg(v);
-            }
-            ExpirySet::UnixSeconds(v) => {
-                cmd.arg("EXAT").arg(v);
-            }
-            ExpirySet::UnixMilliseconds(v) => {
-                cmd.arg("PXAT").arg(v);
-            }
-            ExpirySet::KeepExisting => {
-                cmd.arg("KEEPTTL");
-            }
-            ExpirySet::Persist => {
-                cmd.arg("PERSIST");
-            }
-        }
-    }
-}
-
 /// Conditions for `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT`.
 ///
 /// Mirrors Python `ExpireOptions`.
@@ -346,25 +302,6 @@ mod tests {
         let mut cmd = Cmd::new();
         ConditionalChange::OnlyIfDoesNotExist.add_to(&mut cmd);
         assert_eq!(args_of(&cmd), vec!["NX"]);
-    }
-
-    #[test]
-    fn expiry_set_args() {
-        let mut cmd = Cmd::new();
-        ExpirySet::Seconds(60).add_to(&mut cmd);
-        assert_eq!(args_of(&cmd), vec!["EX", "60"]);
-
-        let mut cmd = Cmd::new();
-        ExpirySet::Milliseconds(1500).add_to(&mut cmd);
-        assert_eq!(args_of(&cmd), vec!["PX", "1500"]);
-
-        let mut cmd = Cmd::new();
-        ExpirySet::KeepExisting.add_to(&mut cmd);
-        assert_eq!(args_of(&cmd), vec!["KEEPTTL"]);
-
-        let mut cmd = Cmd::new();
-        ExpirySet::Persist.add_to(&mut cmd);
-        assert_eq!(args_of(&cmd), vec!["PERSIST"]);
     }
 
     #[test]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -38,7 +38,7 @@ pub use commands::prelude::*;
 
 /// All shared option types.
 pub use commands::options::{
-    ClientPauseMode, ConditionalChange, ExpireOptions, ExpirySet, FlushMode, FunctionRestorePolicy,
+    ClientPauseMode, ConditionalChange, ExpireOptions, FlushMode, FunctionRestorePolicy,
     HashFieldConditionalChange, Limit, MigrateOptions, ObjectType, OrderBy, RestoreOptions,
 };
 

--- a/rust/tests/it_hash.rs
+++ b/rust/tests/it_hash.rs
@@ -5,7 +5,8 @@ mod common;
 
 use glide::AsyncCommands;
 use glide::HashCommands;
-use glide::commands::options::ExpireOptions; // surviving native extensions: hmget, hstrlen, hrandfield*, hexpire/httl/etc.
+use glide::commands::options::{ExpireOptions, HashFieldConditionalChange};
+use redis::{Expiry, SetExpiry};
 
 matrix_test!(hset_hget, c, {
     let k = common::key("h");
@@ -184,23 +185,25 @@ matrix_test!(hset_wrong_type_errors, c, {
 });
 
 // ---------------------------------------------------------------------------
-// Hash-field TTL (Valkey/Redis 7.4+). Gated on the server actually supporting
-// HEXPIRE (via COMMAND INFO) rather than a version number.
+// Hash-field TTL (Valkey/Redis 7.4+).
 // ---------------------------------------------------------------------------
 
 matrix_test!(hexpire_and_httl, c, {
     skip_unless_command!(c, "HEXPIRE");
     let k = common::key("h_ttl");
+
     let _: () = c
         .hset_multiple(&k, &[("f1", "v1"), ("f2", "v2")])
         .await
         .unwrap();
+
     // Set a 100s TTL on f1 only.
     let res = c.hexpire(&k, 100, &["f1"], None).await.unwrap();
     assert_eq!(res, vec![1]); // 1 = expiry set
+
     // HTTL: f1 has a positive TTL, f2 has none (-1), missing field is -2.
     let ttls = c.httl(&k, &["f1", "f2", "missing"]).await.unwrap();
-    assert!(ttls[0] > 0 && ttls[0] <= 100);
+    assert!((1..=100).contains(&ttls[0]));
     assert_eq!(ttls[1], -1);
     assert_eq!(ttls[2], -2);
 });
@@ -236,12 +239,14 @@ matrix_test!(hpexpire_and_hpttl, c, {
     skip_unless_command!(c, "HEXPIRE");
     let k = common::key("h_pttl");
     let _: () = c.hset_multiple(&k, &[("f", "v")]).await.unwrap();
+
     assert_eq!(
         c.hpexpire(&k, 100_000, &["f"], None).await.unwrap(),
         vec![1]
     );
-    let pttls = c.hpttl(&k, &["f"]).await.unwrap();
-    assert!(pttls[0] > 0 && pttls[0] <= 100_000);
+
+    let pttl = c.hpttl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=100_000).contains(&pttl));
 });
 
 matrix_test!(hexpiretime_absolute, c, {
@@ -255,4 +260,108 @@ matrix_test!(hexpiretime_absolute, c, {
     );
     let et = c.hexpiretime(&k, &["f"]).await.unwrap();
     assert_eq!(et[0], future);
+});
+
+// ---------------------------------------------------------------------------
+// HGETEX / HSETEX (Valkey/Redis 9.0+).
+// ---------------------------------------------------------------------------
+
+matrix_test!(hgetex, c, {
+    skip_unless_command!(c, "HGETEX");
+    let k = common::key("h_getex");
+    let _: () = c.hset(&k, "f", "v").await.unwrap();
+
+    // HGETEX with EX.
+    let vals = c.hgetex(&k, &["f"], Some(Expiry::EX(100))).await.unwrap();
+    assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=100).contains(&ttl));
+
+    // HGETEX with PERSIST.
+    let vals = c.hgetex(&k, &["f"], Some(Expiry::PERSIST)).await.unwrap();
+    assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(ttl, -1); // -1 = field exists with no TTL
+});
+
+matrix_test!(hsetex, c, {
+    skip_unless_command!(c, "HSETEX");
+    let k = common::key("h_setex");
+
+    // HSETEX wuth FNX and EX.
+    let res = c
+        .hsetex(
+            &k,
+            &[("f", "v1")],
+            Some(HashFieldConditionalChange::OnlyIfNoneExist),
+            Some(SetExpiry::EX(100)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let v: Option<String> = c.hget(&k, "f").await.unwrap();
+    assert_eq!(v.as_deref(), Some("v1"));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=100).contains(&ttl));
+
+    let res = c
+        .hsetex(
+            &k,
+            &[("f", "v2")],
+            Some(HashFieldConditionalChange::OnlyIfNoneExist),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, 0);
+    let v: Option<String> = c.hget(&k, "f").await.unwrap();
+    assert_eq!(v.as_deref(), Some("v1"));
+
+    // HSETEX with FXX and EX.
+    let res = c
+        .hsetex(
+            &k,
+            &[("f", "v3")],
+            Some(HashFieldConditionalChange::OnlyIfAllExist),
+            Some(SetExpiry::EX(50)),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let v: Option<String> = c.hget(&k, "f").await.unwrap();
+    assert_eq!(v.as_deref(), Some("v3"));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=50).contains(&ttl));
+
+    let res = c
+        .hsetex(
+            &k,
+            &[("g", "gv")],
+            Some(HashFieldConditionalChange::OnlyIfAllExist),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(res, 0);
+    let g: Option<String> = c.hget(&k, "g").await.unwrap();
+    assert_eq!(g, None);
+
+    // HSETEX with KEEPTTL.
+    let res = c
+        .hsetex(&k, &[("f", "v4")], None, Some(SetExpiry::KEEPTTL))
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let v: Option<String> = c.hget(&k, "f").await.unwrap();
+    assert_eq!(v.as_deref(), Some("v4"));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=50).contains(&ttl));
+
+    // HSETEX with no expiry option.
+    let res = c.hsetex(&k, &[("f", "v5")], None, None).await.unwrap();
+    assert_eq!(res, 1);
+    let v: Option<String> = c.hget(&k, "f").await.unwrap();
+    assert_eq!(v.as_deref(), Some("v5"));
+    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(ttl, -1);
 });

--- a/rust/tests/it_hash.rs
+++ b/rust/tests/it_hash.rs
@@ -347,6 +347,7 @@ matrix_test!(hsetex, c, {
     assert_eq!(g, None);
 
     // HSETEX with KEEPTTL.
+    let before = c.hpttl(&k, &["f"]).await.unwrap()[0];
     let res = c
         .hsetex(&k, &[("f", "v4")], None, Some(SetExpiry::KEEPTTL))
         .await
@@ -354,8 +355,8 @@ matrix_test!(hsetex, c, {
     assert_eq!(res, 1);
     let v: Option<String> = c.hget(&k, "f").await.unwrap();
     assert_eq!(v.as_deref(), Some("v4"));
-    let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
-    assert!((1..=50).contains(&ttl));
+    let after = c.hpttl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=before).contains(&after));
 
     // HSETEX with no expiry option.
     let res = c.hsetex(&k, &[("f", "v5")], None, None).await.unwrap();

--- a/rust/tests/it_hash.rs
+++ b/rust/tests/it_hash.rs
@@ -288,7 +288,7 @@ matrix_test!(hsetex, c, {
     skip_unless_command!(c, "HSETEX");
     let k = common::key("h_setex");
 
-    // HSETEX wuth FNX and EX.
+    // HSETEX with FNX and EX.
     let res = c
         .hsetex(
             &k,

--- a/rust/tests/it_hash.rs
+++ b/rust/tests/it_hash.rs
@@ -282,7 +282,10 @@ matrix_test!(hgetex, c, {
     assert!((1..=100).contains(&ttl));
 
     // HGETEX with PX.
-    let vals = c.hgetex(&k, &["f"], Some(Expiry::PX(100_000))).await.unwrap();
+    let vals = c
+        .hgetex(&k, &["f"], Some(Expiry::PX(100_000)))
+        .await
+        .unwrap();
     assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
     let pttl = c.hpttl(&k, &["f"]).await.unwrap()[0];
     assert!((1..=100_000).contains(&pttl));
@@ -385,7 +388,12 @@ matrix_test!(hsetex, c, {
 
     // HSETEX with EXAT.
     let res = c
-        .hsetex(&k, &[("f", "v5")], None, Some(SetExpiry::EXAT(FUTURE_EXPIRY_SECS)))
+        .hsetex(
+            &k,
+            &[("f", "v5")],
+            None,
+            Some(SetExpiry::EXAT(FUTURE_EXPIRY_SECS)),
+        )
         .await
         .unwrap();
     assert_eq!(res, 1);
@@ -394,7 +402,12 @@ matrix_test!(hsetex, c, {
 
     // HSETEX with PXAT.
     let res = c
-        .hsetex(&k, &[("f", "v6")], None, Some(SetExpiry::PXAT(FUTURE_EXPIRY_MS)))
+        .hsetex(
+            &k,
+            &[("f", "v6")],
+            None,
+            Some(SetExpiry::PXAT(FUTURE_EXPIRY_MS)),
+        )
         .await
         .unwrap();
     assert_eq!(res, 1);

--- a/rust/tests/it_hash.rs
+++ b/rust/tests/it_hash.rs
@@ -8,6 +8,10 @@ use glide::HashCommands;
 use glide::commands::options::{ExpireOptions, HashFieldConditionalChange};
 use redis::{Expiry, SetExpiry};
 
+/// Max seconds and milliseconds for future expiry.
+const FUTURE_EXPIRY_SECS: usize = (i64::MAX / 1_000_i64) as usize;
+const FUTURE_EXPIRY_MS: usize = i64::MAX as usize;
+
 matrix_test!(hset_hget, c, {
     let k = common::key("h");
     // HSET with multiple fields returns the count of NEW fields added.
@@ -277,6 +281,30 @@ matrix_test!(hgetex, c, {
     let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
     assert!((1..=100).contains(&ttl));
 
+    // HGETEX with PX.
+    let vals = c.hgetex(&k, &["f"], Some(Expiry::PX(100_000))).await.unwrap();
+    assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
+    let pttl = c.hpttl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=100_000).contains(&pttl));
+
+    // HGETEX with EXAT.
+    let vals = c
+        .hgetex(&k, &["f"], Some(Expiry::EXAT(FUTURE_EXPIRY_SECS)))
+        .await
+        .unwrap();
+    assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
+    let et = c.hexpiretime(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(et, FUTURE_EXPIRY_SECS as i64);
+
+    // HGETEX with PXAT.
+    let vals = c
+        .hgetex(&k, &["f"], Some(Expiry::PXAT(FUTURE_EXPIRY_MS)))
+        .await
+        .unwrap();
+    assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
+    let pet = c.hpexpiretime(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(pet, FUTURE_EXPIRY_MS as i64);
+
     // HGETEX with PERSIST.
     let vals = c.hgetex(&k, &["f"], Some(Expiry::PERSIST)).await.unwrap();
     assert_eq!(vals[0].as_deref(), Some(&b"v"[..]));
@@ -346,23 +374,50 @@ matrix_test!(hsetex, c, {
     let g: Option<String> = c.hget(&k, "g").await.unwrap();
     assert_eq!(g, None);
 
+    // HSETEX with PX.
+    let res = c
+        .hsetex(&k, &[("f", "v4")], None, Some(SetExpiry::PX(100_000)))
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let pttl = c.hpttl(&k, &["f"]).await.unwrap()[0];
+    assert!((1..=100_000).contains(&pttl));
+
+    // HSETEX with EXAT.
+    let res = c
+        .hsetex(&k, &[("f", "v5")], None, Some(SetExpiry::EXAT(FUTURE_EXPIRY_SECS)))
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let et = c.hexpiretime(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(et, FUTURE_EXPIRY_SECS as i64);
+
+    // HSETEX with PXAT.
+    let res = c
+        .hsetex(&k, &[("f", "v6")], None, Some(SetExpiry::PXAT(FUTURE_EXPIRY_MS)))
+        .await
+        .unwrap();
+    assert_eq!(res, 1);
+    let pet = c.hpexpiretime(&k, &["f"]).await.unwrap()[0];
+    assert_eq!(pet, FUTURE_EXPIRY_MS as i64);
+
     // HSETEX with KEEPTTL.
     let before = c.hpttl(&k, &["f"]).await.unwrap()[0];
     let res = c
-        .hsetex(&k, &[("f", "v4")], None, Some(SetExpiry::KEEPTTL))
+        .hsetex(&k, &[("f", "v7")], None, Some(SetExpiry::KEEPTTL))
         .await
         .unwrap();
     assert_eq!(res, 1);
     let v: Option<String> = c.hget(&k, "f").await.unwrap();
-    assert_eq!(v.as_deref(), Some("v4"));
+    assert_eq!(v.as_deref(), Some("v7"));
     let after = c.hpttl(&k, &["f"]).await.unwrap()[0];
     assert!((1..=before).contains(&after));
 
     // HSETEX with no expiry option.
-    let res = c.hsetex(&k, &[("f", "v5")], None, None).await.unwrap();
+    let res = c.hsetex(&k, &[("f", "v8")], None, None).await.unwrap();
     assert_eq!(res, 1);
     let v: Option<String> = c.hget(&k, "f").await.unwrap();
-    assert_eq!(v.as_deref(), Some("v5"));
+    assert_eq!(v.as_deref(), Some("v8"));
     let ttl = c.httl(&k, &["f"]).await.unwrap()[0];
     assert_eq!(ttl, -1);
 });

--- a/rust/tests/mock_commands/hash.rs
+++ b/rust/tests/mock_commands/hash.rs
@@ -3,8 +3,8 @@
 use super::Mock;
 use bytes::Bytes;
 use glide::commands::hash::HashCommands;
-use glide::commands::options::{ExpireOptions, ExpirySet};
-use redis::Value;
+use glide::commands::options::ExpireOptions;
+use redis::{Expiry, SetExpiry, Value};
 
 #[tokio::test]
 async fn hmget_vec() {
@@ -74,10 +74,7 @@ async fn httl_and_hpersist() {
 #[tokio::test]
 async fn hgetex_and_hsetex() {
     let m = Mock::array(vec![Value::BulkString(b"v1".to_vec().into())]);
-    let v = m
-        .hgetex("h", &["f1"], Some(ExpirySet::Seconds(60)))
-        .await
-        .unwrap();
+    let v = m.hgetex("h", &["f1"], Some(Expiry::EX(60))).await.unwrap();
     m.assert_args(&["HGETEX", "h", "EX", "60", "FIELDS", "1", "f1"]);
     assert_eq!(v, vec![Some(Bytes::from_static(b"v1"))]);
 
@@ -160,13 +157,7 @@ async fn hgetex_encoding() {
     assert_eq!(r[1], None);
 
     let m = Mock::array(vec![Value::BulkString(b"v1".to_vec().into())]);
-    m.hgetex(
-        "h",
-        &["f1"],
-        Some(glide::commands::options::ExpirySet::Seconds(60)),
-    )
-    .await
-    .unwrap();
+    m.hgetex("h", &["f1"], Some(Expiry::EX(60))).await.unwrap();
     m.assert_args(&["HGETEX", "h", "EX", "60", "FIELDS", "1", "f1"]);
 }
 
@@ -182,7 +173,7 @@ async fn hsetex_encoding() {
         "h",
         &[("f1", "v1")],
         Some(glide::commands::options::HashFieldConditionalChange::OnlyIfNoneExist),
-        Some(glide::commands::options::ExpirySet::Seconds(60)),
+        Some(SetExpiry::EX(60)),
     )
     .await
     .unwrap();


### PR DESCRIPTION
### Summary

`hgetex` and `hsetex` shared one `ExpirySet` enum exposing every expiry option, so
options each command rejects (`HGETEX`+`KEEPTTL`, `HSETEX`+`PERSIST`) compiled but
failed at the server. This PR updates each command to instead use the existing
`redis-rs` expiry type — `hgetex` uses `redis::Expiry`, `hsetex` uses `redis::SetExpiry` —
so the invalid combinations no longer compile. The glide-only `ExpirySet` enum is removed.

### Issue link

Closes #6934

### Features / Behaviour Changes

- Public API change: `hgetex` now takes `Option<redis::Expiry>`, `hsetex` takes `Option<redis::SetExpiry>`.
- Invalid expiry options are now compile errors instead of runtime server errors.
- `glide::ExpirySet` is removed; use `glide::redis::{Expiry, SetExpiry}` (the types `GETEX`/`SET` already use).

### Implementation

- Reusing the redis-rs types required a `ToRedisArgs` impl for each.
- `get_ex` and `SetOptions` now use those implementationss too.

### Limitations

:white-circle: None

### Testing

- Added new integration tests to `it_hash`:
  - `hgetex` — EX sets a TTL, PERSIST clears it.
  - `hsetex` — FNX/FXX conditions, KEEPTTL retains the TTL, bare HSETEX clears it.

### Checklist

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] ~~CHANGELOG.md and documentation files are updated.~~ :white_circle: N/A (preview crate; rustdoc updated on the changed methods)
- [x] Linters have been run (`cargo clippy`, `cargo fmt`).
- [x] Destination branch is correct - main
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [x] ~~Update the valkey-glide-docs repository.~~ :white_circle: N/A
