### PR TITLE
fix(core): seed MONITOR and PubSub streams from decoder leftover buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: Stop MONITOR and PubSub streams from dropping buffered handshake bytes ([#6979](https://github.com/valkey-io/valkey-glide/pull/6979))
 * Java: Fix scoped connection truncating values larger than 16 KB ([#6893](https://github.com/valkey-io/valkey-glide/issues/6893))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))
 * Core/FFI: Standalone AZ-affinity reads skip nodes that are reconnecting instead of blocking on them; accept `AllNodes` in `create_client_from_uri`'s `read_from` option ([#6721](https://github.com/valkey-io/valkey-glide/pull/6721))

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -70,7 +70,7 @@ where
     Ok(())
 }
 #[cfg(feature = "tokio-comp")]
-use tokio_util::codec::Decoder;
+use tokio_util::codec::{Framed, FramedParts};
 
 /// Represents a stateful redis TCP connection.
 #[deprecated(note = "aio::Connection is deprecated. Use aio::MultiplexedConnection instead.")]
@@ -129,6 +129,17 @@ where
     /// Fetches a single response from the connection.
     async fn read_response(&mut self) -> RedisResult<Value> {
         crate::parser::parse_redis_value_async(&mut self.decoder, &mut self.con).await
+    }
+
+    /// Takes out the bytes the decoder read past the last parsed response.
+    ///
+    /// Ownership moves to the caller, so these bytes are parsed exactly once.
+    /// `combine`'s decoder has no in-place clear, so the reset is a replacement,
+    /// which is also how the decoder is built in the first place.
+    fn take_decoder_buffer(&mut self) -> bytes::BytesMut {
+        let leftover = bytes::BytesMut::from(self.decoder.buffer());
+        self.decoder = combine::stream::Decoder::new();
+        leftover
     }
 
     /// Brings [`Connection`] out of `PubSub` mode.
@@ -384,8 +395,11 @@ where
     /// The message itself is still generic and can be converted into an appropriate type through
     /// the helper methods on it.
     pub fn on_message(&mut self) -> impl Stream<Item = Msg> + '_ {
-        ValueCodec::default()
-            .framed(&mut self.0.con)
+        // Hand the buffered bytes to the stream rather than copying them: the stream
+        // owns them now, so leaving a copy behind would replay delivered messages on
+        // the next call.
+        let leftover = self.0.take_decoder_buffer();
+        framed_with_leftover(&mut self.0.con, leftover)
             .filter_map(|msg| Box::pin(async move { Msg::from_value(&msg.ok()?.ok()?) }))
     }
 
@@ -395,9 +409,9 @@ where
     /// the helper methods on it.
     /// This can be useful in cases where the stream needs to be returned or held by something other
     /// than the [`PubSub`].
-    pub fn into_on_message(self) -> impl Stream<Item = Msg> {
-        ValueCodec::default()
-            .framed(self.0.con)
+    pub fn into_on_message(mut self) -> impl Stream<Item = Msg> {
+        let leftover = self.0.take_decoder_buffer();
+        framed_with_leftover(self.0.con, leftover)
             .filter_map(|msg| Box::pin(async move { Msg::from_value(&msg.ok()?.ok()?) }))
     }
 
@@ -425,22 +439,55 @@ where
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection
-    pub fn on_message<T: FromRedisValue>(&mut self) -> impl Stream<Item = T> + '_ {
-        ValueCodec::default()
-            .framed(&mut self.0.con)
-            .filter_map(|value| {
-                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
-            })
+    pub fn on_message<'a, T: FromRedisValue + 'a>(&'a mut self) -> impl Stream<Item = T> + 'a {
+        // Hand the buffered bytes to the stream rather than copying them: the stream
+        // owns them now, so leaving a copy behind would replay delivered lines on the
+        // next call.
+        let leftover = self.0.take_decoder_buffer();
+        monitor_stream(&mut self.0.con, leftover)
     }
 
     /// Returns [`Stream`] of [`FromRedisValue`] values from this [`Monitor`]ing connection
-    pub fn into_on_message<T: FromRedisValue>(self) -> impl Stream<Item = T> {
-        ValueCodec::default()
-            .framed(self.0.con)
-            .filter_map(|value| {
-                Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
-            })
+    pub fn into_on_message<T: FromRedisValue>(mut self) -> impl Stream<Item = T> {
+        let leftover = self.0.take_decoder_buffer();
+        monitor_stream(self.0.con, leftover)
     }
+}
+
+/// Builds a [`ValueCodec`] [`Framed`] over `con`, seeding its read buffer with
+/// the `leftover` bytes the connection decoder read past the handshake.
+///
+/// A stream handshake (`MONITOR`, `SUBSCRIBE`, `PSUBSCRIBE`) is parsed through
+/// `Connection::decoder`, which reads from the socket in chunks. Under load the
+/// server can pack the first stream payload into the same TCP segment as the
+/// handshake reply, leaving those bytes buffered inside the decoder. Building the
+/// stream's codec over the bare socket would drop that buffer, and the damage
+/// depends on how much was buffered: a complete frame is lost outright, while a
+/// partial frame leaves the new codec resuming mid-frame, which fails to parse and
+/// ends the stream before it delivers anything. Seeding the read buffer with the
+/// leftover bytes avoids both.
+///
+/// The `Monitor` and `PubSub` stream constructors all route through here, over the
+/// borrowed `&mut con` and the moved `con` alike, so every path stays in step.
+fn framed_with_leftover<C>(con: C, leftover: bytes::BytesMut) -> Framed<C, ValueCodec>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut parts = FramedParts::new::<Vec<u8>>(con, ValueCodec::default());
+    parts.read_buf = leftover;
+    Framed::from_parts(parts)
+}
+
+/// Builds a MONITOR line [`Stream`] over `con`, seeding the framed read buffer
+/// with the `leftover` bytes the connection decoder read past the handshake.
+fn monitor_stream<C, T>(con: C, leftover: bytes::BytesMut) -> impl Stream<Item = T>
+where
+    C: AsyncRead + AsyncWrite + Unpin,
+    T: FromRedisValue,
+{
+    framed_with_leftover(con, leftover).filter_map(|value| {
+        Box::pin(async move { T::from_owned_redis_value(value.ok()?.ok()?).ok() })
+    })
 }
 
 pub(crate) async fn get_socket_addrs(
@@ -545,4 +592,328 @@ pub(crate) async fn connect_simple<T: RedisRuntime>(
             )))
         }
     })
+}
+
+#[cfg(all(test, feature = "tokio-comp"))]
+mod monitor_tests {
+    use super::*;
+    use ::tokio::io::{duplex, AsyncWriteExt, DuplexStream};
+    use ::tokio::sync::oneshot;
+
+    // A MONITOR line as the server sends it: a RESP simple string.
+    const MONITOR_LINE: &str = "+1720000000.000000 [0 127.0.0.1:6379] \"SET\" \"k\" \"v\"\r\n";
+
+    // Wraps a `Monitor` around the client end of an in-memory duplex, matching a
+    // connection that has finished setup. The decoder starts empty; each test fills
+    // it by running the real `MONITOR` handshake through `monitor()`.
+    fn monitor_over(client: DuplexStream) -> Monitor<DuplexStream> {
+        Monitor::new(Connection {
+            con: client,
+            buf: Vec::new(),
+            decoder: combine::stream::Decoder::new(),
+            db: 0,
+            pubsub: false,
+            protocol: ProtocolVersion::RESP2,
+        })
+    }
+
+    // The server can pack the first monitor line into the same segment as the `+OK`
+    // handshake reply. `monitor()` reads `+OK` through the decoder, which over-reads
+    // and leaves the whole monitor line sitting in `decoder`. The borrowed
+    // `on_message()` has to hand that line back: dropping the buffer (the codec built
+    // over the bare socket) hangs here, because the socket has nothing left to read.
+    #[tokio::test]
+    async fn on_message_delivers_fully_buffered_line() {
+        let (client, mut server) = duplex(4096);
+
+        let mut handshake = String::from("+OK\r\n");
+        handshake.push_str(MONITOR_LINE);
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut monitor = monitor_over(client);
+        monitor.monitor().await.unwrap();
+
+        // Check the precondition instead of assuming it: the handshake read has to
+        // pull the whole monitor line into the decoder, so the socket holds nothing more.
+        assert_eq!(
+            monitor.0.decoder.buffer(),
+            MONITOR_LINE.as_bytes(),
+            "handshake did not buffer the monitor line, so the test would not exercise the handoff"
+        );
+
+        // Hold the server end open so a buffer-dropping stream blocks on the socket
+        // rather than seeing EOF, which makes a timeout here a real failure signal.
+        let (_stop_tx, stop_rx) = oneshot::channel::<()>();
+        let _server_task = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            drop(server);
+        });
+
+        let mut stream = monitor.on_message::<String>();
+        let line = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("borrowed on_message dropped the buffered monitor line")
+            .expect("stream ended before delivering the buffered monitor line");
+        assert!(line.contains("\"SET\""), "unexpected monitor line: {line}");
+    }
+
+    // When only part of the first monitor line was buffered with `+OK`, the borrowed
+    // `on_message()` has to resume the frame from the buffered prefix and read the rest
+    // from the socket. A fresh codec over the bare socket starts mid-frame on the
+    // remaining bytes, hits a parse error, and ends the stream with zero lines.
+    #[tokio::test]
+    async fn on_message_recovers_partially_buffered_line() {
+        let (client, mut server) = duplex(4096);
+
+        let split = MONITOR_LINE.len() / 2;
+        let mut first = String::from("+OK\r\n");
+        first.push_str(&MONITOR_LINE[..split]);
+        server.write_all(first.as_bytes()).await.unwrap();
+
+        let mut monitor = monitor_over(client);
+        monitor.monitor().await.unwrap();
+
+        // Check the precondition: the prefix has to be sitting in the decoder mid-frame,
+        // which is what makes dropping it resume parsing at the wrong offset.
+        assert_eq!(
+            monitor.0.decoder.buffer(),
+            &MONITOR_LINE.as_bytes()[..split],
+            "handshake did not buffer the partial monitor line prefix"
+        );
+
+        // Send the remainder only after the handshake read has buffered the prefix.
+        let rest = MONITOR_LINE[split..].to_string();
+        let _server_task = tokio::spawn(async move {
+            server.write_all(rest.as_bytes()).await.unwrap();
+            ::tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            drop(server);
+        });
+
+        let mut stream = monitor.on_message::<String>();
+        let line = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("borrowed on_message terminated on the partially buffered line")
+            .expect("stream ended before delivering the partially buffered line");
+        assert!(line.contains("\"SET\""), "unexpected monitor line: {line}");
+    }
+
+    // The borrowed path hands the decoder's bytes to the stream, so it also has to take
+    // them out of the decoder. Otherwise dropping one stream and building another
+    // replays lines the first stream already delivered.
+    #[tokio::test]
+    async fn on_message_does_not_replay_buffered_line_across_streams() {
+        let (client, mut server) = duplex(4096);
+
+        let mut handshake = String::from("+OK\r\n");
+        handshake.push_str(MONITOR_LINE);
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut monitor = monitor_over(client);
+        monitor.monitor().await.unwrap();
+        assert_eq!(monitor.0.decoder.buffer(), MONITOR_LINE.as_bytes());
+
+        {
+            let mut first = monitor.on_message::<String>();
+            let line = ::tokio::time::timeout(std::time::Duration::from_secs(2), first.next())
+                .await
+                .expect("first borrowed stream did not deliver the buffered line")
+                .expect("first borrowed stream ended early");
+            assert!(line.contains("\"SET\""), "unexpected monitor line: {line}");
+        }
+
+        // The first stream consumed the line, so a second stream must not see it again.
+        // Only the server's next write should ever surface here.
+        let mut second = monitor.on_message::<String>();
+        let replayed =
+            ::tokio::time::timeout(std::time::Duration::from_millis(200), second.next()).await;
+        assert!(
+            replayed.is_err(),
+            "second borrowed stream replayed an already-delivered line: {replayed:?}"
+        );
+
+        drop(second);
+        drop(server);
+    }
+}
+
+#[cfg(all(test, feature = "tokio-comp"))]
+mod pubsub_tests {
+    use super::*;
+    use ::tokio::io::{duplex, AsyncWriteExt, DuplexStream};
+    use ::tokio::sync::oneshot;
+
+    const CHANNEL: &str = "ch";
+    const PAYLOAD: &str = "hello";
+
+    // The RESP2 confirmation the server sends in reply to SUBSCRIBE.
+    fn subscribe_confirmation() -> String {
+        format!(
+            "*3\r\n$9\r\nsubscribe\r\n${}\r\n{}\r\n:1\r\n",
+            CHANNEL.len(),
+            CHANNEL
+        )
+    }
+
+    // The RESP2 frame for a published message on `CHANNEL`.
+    fn message_frame() -> String {
+        format!(
+            "*3\r\n$7\r\nmessage\r\n${}\r\n{}\r\n${}\r\n{}\r\n",
+            CHANNEL.len(),
+            CHANNEL,
+            PAYLOAD.len(),
+            PAYLOAD
+        )
+    }
+
+    // Wraps a `PubSub` around the client end of an in-memory duplex, matching a
+    // connection that has finished setup. The decoder starts empty; each test fills
+    // it by running the real `SUBSCRIBE` handshake through `subscribe()` in RESP2,
+    // where the confirmation is parsed through `decoder` and no_response is not set.
+    fn pubsub_over(client: DuplexStream) -> PubSub<DuplexStream> {
+        PubSub::new(Connection {
+            con: client,
+            buf: Vec::new(),
+            decoder: combine::stream::Decoder::new(),
+            db: 0,
+            pubsub: false,
+            protocol: ProtocolVersion::RESP2,
+        })
+    }
+
+    fn assert_expected_message(msg: Msg) {
+        assert_eq!(msg.get_channel_name(), CHANNEL, "unexpected channel");
+        assert_eq!(
+            msg.get_payload::<String>().unwrap(),
+            PAYLOAD,
+            "unexpected payload"
+        );
+    }
+
+    // The confirmation is parsed through the combine decoder, whose async read grows
+    // the buffer in increments, so it over-reads a prefix of the message frame rather
+    // than a fixed amount. Asserting that prefix is non-empty and lines up with the
+    // frame is enough to prove the handshake buffered bytes the stream must recover.
+    fn assert_buffered_prefix(buffered: &[u8]) {
+        let frame = message_frame();
+        assert!(
+            !buffered.is_empty(),
+            "handshake did not buffer any of the message frame, so the test would not exercise the handoff"
+        );
+        assert!(
+            frame.as_bytes().starts_with(buffered),
+            "buffered bytes are not a prefix of the message frame: {buffered:?}"
+        );
+    }
+
+    // The server can pack the first published message into the same segment as the
+    // subscribe confirmation. `subscribe()` reads the confirmation through the decoder,
+    // which over-reads and leaves the whole message frame sitting in `decoder`. The
+    // borrowed `on_message()` has to hand that frame back: dropping the buffer (the
+    // codec built over the bare socket) hangs here, because the socket has nothing
+    // left to read.
+    #[tokio::test]
+    async fn on_message_delivers_fully_buffered_message() {
+        let (client, mut server) = duplex(4096);
+
+        let mut handshake = subscribe_confirmation();
+        handshake.push_str(&message_frame());
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut pubsub = pubsub_over(client);
+        pubsub.subscribe(CHANNEL).await.unwrap();
+
+        assert_buffered_prefix(pubsub.0.decoder.buffer());
+
+        // Hold the server end open so a buffer-dropping stream blocks on the socket
+        // rather than seeing EOF, which makes a timeout here a real failure signal.
+        let (_stop_tx, stop_rx) = oneshot::channel::<()>();
+        let _server_task = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            drop(server);
+        });
+
+        let mut stream = pubsub.on_message();
+        let msg = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("borrowed on_message dropped the buffered message")
+            .expect("stream ended before delivering the buffered message");
+        assert_expected_message(msg);
+    }
+
+    // When only part of the first message was buffered with the confirmation, the
+    // borrowed `on_message()` has to resume the frame from the buffered prefix and read
+    // the rest from the socket. A fresh codec over the bare socket starts mid-frame on
+    // the remaining bytes, hits a parse error, and ends the stream with zero messages.
+    #[tokio::test]
+    async fn on_message_recovers_partially_buffered_message() {
+        let (client, mut server) = duplex(4096);
+
+        let frame = message_frame();
+        let split = frame.len() / 2;
+        let mut first = subscribe_confirmation();
+        first.push_str(&frame[..split]);
+        server.write_all(first.as_bytes()).await.unwrap();
+
+        let mut pubsub = pubsub_over(client);
+        pubsub.subscribe(CHANNEL).await.unwrap();
+
+        assert_eq!(
+            pubsub.0.decoder.buffer(),
+            &frame.as_bytes()[..split],
+            "handshake did not buffer the partial message prefix"
+        );
+
+        // Send the remainder only after the handshake read has buffered the prefix.
+        let rest = frame[split..].to_string();
+        let _server_task = tokio::spawn(async move {
+            server.write_all(rest.as_bytes()).await.unwrap();
+            ::tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            drop(server);
+        });
+
+        let mut stream = pubsub.on_message();
+        let msg = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .expect("borrowed on_message terminated on the partially buffered message")
+            .expect("stream ended before delivering the partially buffered message");
+        assert_expected_message(msg);
+    }
+
+    // The borrowed path hands the decoder's bytes to the stream, so it also has to take
+    // them out of the decoder. Otherwise dropping one stream and building another
+    // replays messages the first stream already delivered.
+    #[tokio::test]
+    async fn on_message_does_not_replay_buffered_message_across_streams() {
+        let (client, mut server) = duplex(4096);
+
+        let mut handshake = subscribe_confirmation();
+        handshake.push_str(&message_frame());
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut pubsub = pubsub_over(client);
+        pubsub.subscribe(CHANNEL).await.unwrap();
+        assert_buffered_prefix(pubsub.0.decoder.buffer());
+
+        {
+            let mut first = pubsub.on_message();
+            let msg = ::tokio::time::timeout(std::time::Duration::from_secs(2), first.next())
+                .await
+                .expect("first borrowed stream did not deliver the buffered message")
+                .expect("first borrowed stream ended early");
+            assert_expected_message(msg);
+        }
+
+        // The first stream consumed the message, so a second stream must not see it
+        // again. Only the server's next write should ever surface here.
+        let mut second = pubsub.on_message();
+        let replayed =
+            ::tokio::time::timeout(std::time::Duration::from_millis(200), second.next()).await;
+        assert!(
+            replayed.is_err(),
+            "second borrowed stream replayed an already-delivered message: {replayed:?}"
+        );
+
+        drop(second);
+        drop(server);
+    }
 }

--- a/glide-core/redis-rs/redis/src/aio/connection.rs
+++ b/glide-core/redis-rs/redis/src/aio/connection.rs
@@ -734,6 +734,58 @@ mod monitor_tests {
         drop(second);
         drop(server);
     }
+
+    // The handshake read can over-read more than one line: two lines can share the
+    // segment that carried `+OK`, so both land in the decoder. A single borrowed
+    // stream owns the whole leftover, so it has to hand back both lines in order,
+    // decoding the second from the seeded buffer once the first is consumed.
+    #[tokio::test]
+    async fn on_message_delivers_two_buffered_lines() {
+        let (client, mut server) = duplex(4096);
+
+        let mut handshake = String::from("+OK\r\n");
+        handshake.push_str(MONITOR_LINE);
+        handshake.push_str(MONITOR_LINE);
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut monitor = monitor_over(client);
+        monitor.monitor().await.unwrap();
+
+        // The read that satisfies `+OK` over-reads a prefix of the two lines; whatever
+        // it buffered has to line up with them, and the stream reads any remainder from
+        // the socket.
+        let two_lines = format!("{MONITOR_LINE}{MONITOR_LINE}");
+        let buffered = monitor.0.decoder.buffer();
+        assert!(
+            !buffered.is_empty(),
+            "handshake did not buffer any of the monitor lines, so the test would not exercise the two-frame handoff"
+        );
+        assert!(
+            two_lines.as_bytes().starts_with(buffered),
+            "buffered bytes are not a prefix of the two monitor lines: {buffered:?}"
+        );
+
+        // Hold the server end open so a stream that mishandles the second line blocks
+        // on the socket rather than seeing EOF, which makes a timeout a real failure.
+        let (_stop_tx, stop_rx) = oneshot::channel::<()>();
+        let _server_task = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            drop(server);
+        });
+
+        let mut stream = monitor.on_message::<String>();
+        for nth in ["first", "second"] {
+            let line = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("borrowed on_message did not deliver the {nth} buffered line")
+                })
+                .unwrap_or_else(|| {
+                    panic!("stream ended before delivering the {nth} buffered line")
+                });
+            assert!(line.contains("\"SET\""), "unexpected monitor line: {line}");
+        }
+    }
 }
 
 #[cfg(all(test, feature = "tokio-comp"))]
@@ -915,5 +967,58 @@ mod pubsub_tests {
 
         drop(second);
         drop(server);
+    }
+
+    // The handshake read can over-read more than one message: two messages can share
+    // the segment that carried the subscribe confirmation, so both land in the decoder.
+    // A single borrowed stream owns the whole leftover, so it has to hand back both
+    // messages in order, decoding the second from the seeded buffer once the first is
+    // consumed.
+    #[tokio::test]
+    async fn on_message_delivers_two_buffered_messages() {
+        let (client, mut server) = duplex(4096);
+
+        let frame = message_frame();
+        let mut handshake = subscribe_confirmation();
+        handshake.push_str(&frame);
+        handshake.push_str(&frame);
+        server.write_all(handshake.as_bytes()).await.unwrap();
+
+        let mut pubsub = pubsub_over(client);
+        pubsub.subscribe(CHANNEL).await.unwrap();
+
+        // The decoder over-reads a prefix of the two frames; whatever it buffered has
+        // to line up with them, and the stream reads any remainder from the socket.
+        let two_frames = format!("{frame}{frame}");
+        let buffered = pubsub.0.decoder.buffer();
+        assert!(
+            !buffered.is_empty(),
+            "handshake did not buffer any of the message frames, so the test would not exercise the two-frame handoff"
+        );
+        assert!(
+            two_frames.as_bytes().starts_with(buffered),
+            "buffered bytes are not a prefix of the two message frames: {buffered:?}"
+        );
+
+        // Hold the server end open so a stream that mishandles the second message blocks
+        // on the socket rather than seeing EOF, which makes a timeout a real failure.
+        let (_stop_tx, stop_rx) = oneshot::channel::<()>();
+        let _server_task = tokio::spawn(async move {
+            let _ = stop_rx.await;
+            drop(server);
+        });
+
+        let mut stream = pubsub.on_message();
+        for nth in ["first", "second"] {
+            let msg = ::tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("borrowed on_message did not deliver the {nth} buffered message")
+                })
+                .unwrap_or_else(|| {
+                    panic!("stream ended before delivering the {nth} buffered message")
+                });
+            assert_expected_message(msg);
+        }
     }
 }


### PR DESCRIPTION
### Summary

The Rust integration test `test_monitor::test_monitor_start_and_receive_line` is flaky because of a product bug in the vendored redis-rs async connection layer, not because the test is slow. Under concurrent load the server can pack the first MONITOR line into the same TCP segment as the `MONITOR` `+OK` handshake reply. The connection's `combine` decoder reads both while parsing `+OK`, so the monitor-line bytes stay buffered inside the decoder. Both `Monitor` stream constructors then built a fresh `ValueCodec` over the bare socket and discarded that buffer: a fully buffered line was lost outright, and a partially buffered line left the new codec resuming mid-frame, where it hit a parse error and ended the stream with zero lines delivered. The sibling `PubSub` stream constructors carry the same defect on the RESP2 subscribe path. This change seeds the new framed stream from the decoder's leftover bytes so no buffered message is lost.

### Issue link

This Pull Request is linked to issue: [Flaky test_monitor::test_monitor_start_and_receive_line](https://github.com/valkey-io/valkey-glide/issues/6390)
Closes #6390

### Features / Behaviour Changes

- MONITOR line streams (`Monitor::on_message`, `Monitor::into_on_message`) deliver every line the server sent, including the first line when the server packed it into the handshake segment.
- PubSub message streams (`PubSub::on_message`, `PubSub::into_on_message`) deliver the first published message on the RESP2 path when it arrived in the same segment as the subscribe confirmation.
- Rebuilding a stream from the same connection no longer replays a message the previous stream already delivered.

### Implementation

- Add `Connection::take_decoder_buffer`, which moves the decoder's unread bytes to the caller and resets the decoder. `combine`'s decoder has no in-place clear, so resetting it means replacing it, the same way it is built.
- Add a shared `framed_with_leftover` helper that constructs the stream through `tokio_util::codec::FramedParts` with its read buffer seeded from those leftover bytes, so the new codec continues from where the decoder stopped.
- Route both `Monitor` constructors and both `PubSub` constructors through the helper. Each keeps its own value mapping: `FromRedisValue` for Monitor, `Msg` for PubSub.

### Limitations

- The RESP3 subscribe path sets `set_no_response`, so its confirmation does not pass through the decoder and never buffers a following message. The fix changes nothing on that path.
- `aio::Connection` remains deprecated in favor of `MultiplexedConnection`. This change repairs the existing behavior without altering that direction.

### Testing

- Added in-crate tests over an in-memory duplex for both Monitor and PubSub. Each packs the first message into the same read as the handshake, asserts the decoder buffered it, then asserts the stream delivers it. The cases cover a fully buffered message, a partially buffered message that resumes mid-frame, a second stream that must not replay a delivered message, and two frames buffered from one handshake segment that a single stream must deliver in order. The PubSub tests drive the real RESP2 subscribe handshake.
- The existing `test_monitor.rs` integration tests keep their 15 second poll deadline and pass.
- Reproduced the original flake by running the monitor tests concurrently under CPU load, then confirmed the fix removes it. `cargo clippy` and `cargo fmt` are clean.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
