### PR TITLE
ci: retry network-dependent install steps to fix flaky dependency install (#6284)

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -11,8 +11,14 @@ runs:
     using: "composite"
     steps:
         - name: Install Rust toolchain
-          uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-          with:
-              toolchain: stable
-              targets: ${{ inputs.target }}
-              components: rustfmt, clippy
+          shell: bash
+          env:
+              TARGET: ${{ inputs.target }}
+          run: |
+              # rustup sync can transiently fail reaching static.rust-lang.org
+              # ("Network is unreachable"), so retry the install up to 3 times before
+              # failing (#6284). The rustup flags match dtolnay/rust-toolchain stable.
+              for i in 1 2 3; do
+                  rustup toolchain install stable --target "$TARGET" --component rustfmt --component clippy --profile minimal --no-self-update && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }
+              done
+              rustup default stable || true

--- a/.github/actions/install-shared-dependencies/action.yml
+++ b/.github/actions/install-shared-dependencies/action.yml
@@ -26,15 +26,17 @@ runs:
           shell: bash
           if: "${{ inputs.os == 'macos' }}"
           run: |
-              brew update
-              brew install openssl coreutils
+              # Retry package downloads to ride out transient network errors (#6284).
+              for i in 1 2 3; do brew update && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
+              for i in 1 2 3; do brew install openssl coreutils && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
 
         - name: Install software dependencies for Ubuntu GNU
           shell: bash
           if: "${{ inputs.os == 'ubuntu' && !contains(inputs.target, 'musl')}}"
           run: |
-              sudo apt update -y
-              sudo apt install -y git gcc pkg-config openssl libssl-dev
+              # Retry package downloads to ride out transient network errors (#6284).
+              for i in 1 2 3; do sudo apt update -y && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
+              for i in 1 2 3; do sudo apt install -y git gcc pkg-config openssl libssl-dev && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
 
         - name: Install software dependencies for MUSL
           shell: bash
@@ -42,7 +44,8 @@ runs:
           env:
               GH_TARGET: ${{ inputs.target }}
           run: |
-              apk update
+              # Retry package downloads to ride out transient network errors (#6284).
+              for i in 1 2 3; do apk update && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
               RUSTUP_DIR=$(mktemp -d)
               RUSTUP_INIT="$RUSTUP_DIR/rustup-init"
               trap 'rm -rf "$RUSTUP_DIR"' EXIT
@@ -60,18 +63,20 @@ runs:
                   exit 1
                   ;;
               esac
-              wget -O "$RUSTUP_INIT" "$RUSTUP_URL"
+              # Retry the download to ride out transient network errors (#6284).
+              for i in 1 2 3; do wget -O "$RUSTUP_INIT" "$RUSTUP_URL" && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
               echo "$RUSTUP_SHA256  $RUSTUP_INIT" | sha256sum -c -
               chmod +x "$RUSTUP_INIT"
               "$RUSTUP_INIT" -y --no-modify-path --default-toolchain stable
               source "$HOME/.cargo/env"
-              apk add protobuf-dev musl-dev make gcc envsubst openssl libressl-dev py3-pip
+              for i in 1 2 3; do apk add protobuf-dev musl-dev make gcc envsubst openssl libressl-dev py3-pip && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
 
         - name: Install software dependencies for Amazon-Linux
           shell: bash
           if: "${{ inputs.os == 'amazon-linux' }}"
           run: |
-              yum install -y gcc pkgconfig openssl openssl-devel which curl gettext libasan libatomic tar --allowerasing
+              # Retry package downloads to ride out transient network errors (#6284).
+              for i in 1 2 3; do yum install -y gcc pkgconfig openssl openssl-devel which curl gettext libasan libatomic tar --allowerasing && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done
 
         - name: Setup WSL (Windows only)
           if: "${{ inputs.os == 'windows' && inputs.engine-version }}"


### PR DESCRIPTION
### Summary

The shared dependency install actions download from external hosts with no retry, so a single transient network error fails the whole CI job. Issue #6284 reports the rustup toolchain sync failing with "Network is unreachable" while reaching static.rust-lang.org on the amazon-linux container. This wraps the network-dependent install steps in a bounded retry loop so a transient failure is retried instead of failing the job.

### Issue link

This Pull Request is linked to issue: [\[Java\]\[Flaky Test\] Install shared software dependencies - Network unreachable](https://github.com/valkey-io/valkey-glide/issues/6284)
Closes #6284

### Features / Behaviour Changes

- Retry the Rust toolchain install, the MUSL rustup-init download, and the apt/apk/yum/brew package installs in `install-shared-dependencies` and `install-rust`.
- Each retry loop makes 3 attempts with a 15 second backoff and hard-fails once the budget is exhausted, so a persistent outage still fails the job rather than being masked as success.
- No product code changes and no change to which dependencies are installed.

### Implementation

Both actions now use the same bounded retry pattern already merged in `install-zig` (#6313): `for i in 1 2 3; do <cmd> && break || { [ "$i" -eq 3 ] && exit 1 || sleep 15; }; done`.

- `.github/actions/install-shared-dependencies/action.yml`: wraps `brew update`/`brew install`, `apt update`/`apt install`, `apk update`/`apk add`, the MUSL `wget` of rustup-init, and the Amazon Linux `yum install` in the retry loop. The MUSL SHA256 checksum verification is unchanged and still runs after the download.
- `.github/actions/install-rust/action.yml`: the `dtolnay/rust-toolchain` step cannot be retried as a `uses:` action, so it is replaced by the equivalent `rustup toolchain install stable --target <target> --component rustfmt --component clippy --profile minimal --no-self-update` invocation inside the retry loop, followed by `rustup default stable`. These flags match what `dtolnay/rust-toolchain` runs for the same inputs, so toolchain, target, and components are unchanged.

The inter-attempt `sleep 15` is retry backoff, not a wait-for-condition sleep.

### Limitations

The `arduino/setup-protoc` and `Vampire/setup-wsl` steps are third-party `uses:` actions with no built-in retry and are left unchanged in this PR to keep the scope focused on the download paths behind #6284.

### Testing

This is a CI-infrastructure change to GitHub Actions YAML with no product code. Verified by:

- Matching the retry loop against the already-merged `install-zig` pattern from #6313 (3 attempts, 15s backoff, hard-fail on exhaustion).
- Hand-checking each embedded shell script: the `&& break || { ... }` form retries on failure, and the final attempt runs `exit 1`, so a persistent failure still fails the step under `bash -eo pipefail`.
- Confirming the replacement rustup flags match `dtolnay/rust-toolchain` for `toolchain: stable`, `targets`, and `components: rustfmt, clippy`.
- Parsing both action YAML files to confirm they are well-formed.

Full CI cannot be run locally for a GitHub Actions change; CI on this PR exercises the modified steps.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [ ] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary
