### PR TITLE
fix(go): keep FFI argument buffers alive across native calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * Java: Map the Jedis compatibility layer's database selection onto GLIDE's `databaseId` instead of logging a warning and discarding it. A `JedisPool` configured for a non-zero database ran every command against database 0, silently writing to a database the caller did not ask for ([#6994](https://github.com/valkey-io/valkey-glide/issues/6994))
-* Go: Keep FFI argument buffers alive across native calls to prevent a GC use-after-free under heavy load ([#5990](https://github.com/valkey-io/valkey-glide/issues/5990))
+* Go: keep FFI argument buffers alive across native calls to prevent GC use-after-free ([#6985](https://github.com/valkey-io/valkey-glide/pull/6985))
 * Core: Mark `PSUBSCRIBE` and `PUNSUBSCRIBE` as readonly commands so cluster routing treats them consistently with `SUBSCRIBE`/`UNSUBSCRIBE` ([#6756](https://github.com/valkey-io/valkey-glide/pull/6756))
 * Java: Fix scoped connection truncating values larger than 16 KB ([#6893](https://github.com/valkey-io/valkey-glide/issues/6893))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 * Java: Map the Jedis compatibility layer's database selection onto GLIDE's `databaseId` instead of logging a warning and discarding it. A `JedisPool` configured for a non-zero database ran every command against database 0, silently writing to a database the caller did not ask for ([#6994](https://github.com/valkey-io/valkey-glide/issues/6994))
+* Go: Keep FFI argument buffers alive across native calls to prevent a GC use-after-free under heavy load ([#5990](https://github.com/valkey-io/valkey-glide/issues/5990))
 * Core: Mark `PSUBSCRIBE` and `PUNSUBSCRIBE` as readonly commands so cluster routing treats them consistently with `SUBSCRIBE`/`UNSUBSCRIBE` ([#6756](https://github.com/valkey-io/valkey-glide/pull/6756))
 * Java: Fix scoped connection truncating values larger than 16 KB ([#6893](https://github.com/valkey-io/valkey-glide/issues/6893))
 * Go: Propagate pool ConnectionRequest into pool-borrowed clients so `ScopedConnection` works on pooled clients ([#6763](https://github.com/valkey-io/valkey-glide/issues/6763))

--- a/go/base_client.go
+++ b/go/base_client.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -420,6 +421,10 @@ func (client *baseClient) executeCommandWithRoute(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep args reachable until C.command returns. toCStrings hands the string data to the
+	// core as bare uintptr values that the GC cannot see, so the backing memory must not be
+	// freed or moved while the core still reads those pointers.
+	runtime.KeepAlive(args)
 	payload, err := client.waitForResponse(ctx, requestID, resultChannel)
 	if err != nil {
 		return nil, err
@@ -501,6 +506,10 @@ func (client *baseClient) executeBatch(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep batch reachable until C.batch returns. createCmdInfo hands the command args to the
+	// core as raw pointers via unsafe.StringData, which the GC cannot see, so the backing
+	// memory must not be freed or moved while the core still reads those pointers.
+	runtime.KeepAlive(batch)
 
 	payload, err := client.waitForResponse(ctx, requestID, resultChannel)
 	if err != nil {
@@ -9892,6 +9901,11 @@ func (client *baseClient) executeScriptWithRoute(
 		C.uint64_t(spanPtr),
 	)
 	client.mu.Unlock()
+	// Keep keys and args reachable until C.invoke_script returns. toCStrings hands the string
+	// data to the core as bare uintptr values that the GC cannot see, so the backing memory
+	// must not be freed or moved while the core still reads those pointers.
+	runtime.KeepAlive(keys)
+	runtime.KeepAlive(args)
 
 	payload, err := client.waitForResponse(ctx, requestID, resultChannel)
 	if err != nil {

--- a/go/glide_cluster_client.go
+++ b/go/glide_cluster_client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strconv"
 	"time"
 	"unsafe"
@@ -695,6 +696,10 @@ func (client *ClusterClient) clusterScan(
 		argLengthsPtr,
 	)
 	client.mu.Unlock()
+	// Keep args reachable until C.request_cluster_scan returns. toCStrings hands the string
+	// data to the core as bare uintptr values that the GC cannot see, so the backing memory
+	// must not be freed or moved while the core still reads those pointers.
+	runtime.KeepAlive(args)
 
 	payload, err := client.waitForResponse(ctx, requestID, resultChannel)
 	if err != nil {

--- a/go/integTest/glide_test_suite_test.go
+++ b/go/integTest/glide_test_suite_test.go
@@ -576,10 +576,13 @@ func (suite *GlideTestSuite) runParallelizedWithClients(
 	for _, client := range clients {
 		suite.T().Run(fmt.Sprintf("%T", client)[1:], func(t *testing.T) {
 			done := make(chan struct{}, parallelism)
+			// Signal goroutines to exit on timeout so they don't outlive the test and
+			// report failures after it has completed.
+			var stopped atomic.Int32
 			for i := 0; i < parallelism; i++ {
 				go func() {
 					defer func() { done <- struct{}{} }()
-					for !suite.T().Failed() && atomic.AddInt64(&count, -1) > 0 {
+					for stopped.Load() == 0 && !suite.T().Failed() && atomic.AddInt64(&count, -1) > 0 {
 						test(client)
 					}
 				}()
@@ -590,6 +593,7 @@ func (suite *GlideTestSuite) runParallelizedWithClients(
 				select {
 				case <-done:
 				case <-tm.C:
+					stopped.Store(1)
 					suite.T().Fatalf("parallelized test timeout")
 				}
 			}


### PR DESCRIPTION
## Intent

Fix the genuine product bug behind the flaky Go test TestGlideTestSuite/TestParallelizedSetWithGC (issue #5990). Root cause: an FFI GC-lifetime defect. In go/base_client.go, toCStrings stores Go string backing bytes as bare uintptr values, and createCmdInfo passes them via unsafe.StringData; both are invisible to the Go GC, and there was no runtime.KeepAlive after the native C.command / C.batch / C.invoke_script / C.request_cluster_scan calls. Under heavy GC pressure the backing memory could be freed or moved while the Rust core still read those pointers, corrupting the payload or stalling the writer (the #3207 class). The test amplifies this with 640 goroutines that each call runtime.GC() before a SET. Fix: runtime.KeepAlive guards for args/keys/batch after each native call in go/base_client.go and go/glide_cluster_client.go, plus the runtime import in both. Deliberate: (1) KeepAlive at four call sites for full FFI-boundary coverage, not just SET. (2) Ported ONLY PR #6857's atomic.Int32 stop-flag test-harness fix in go/integTest/glide_test_suite_test.go; deliberately excluded #6857's ASAN timeout bump and release-2.4-specific pieces. (3) No sleep/retry/skip; the fix is the lifetime guard. This run adds a second commit that only updates the CHANGELOG entry to link the now-created PR #6985 and match its title (the entry text and link were previously pointing at issue #5990 because the PR did not exist yet at first commit time). A prior pipeline run already validated the code fix under AddressSanitizer (the exact test passed cleanly, zero use-after-free); target branch main; draft PR #6985 for captain review, do not merge or un-draft.

## What Changed

- Added `runtime.KeepAlive` guards in `go/base_client.go` after the native `C.command`, `C.batch`, and `C.invoke_script` calls (guarding `args`, `batch`, `keys`), and in `go/glide_cluster_client.go` after `C.request_cluster_scan` (guarding `args`), pulling in the `runtime` import in both files. This prevents the Go GC from freeing or moving string backing memory that `toCStrings`/`unsafe.StringData` hand to the Rust core as bare pointers while the core still reads them, closing a use-after-free that could corrupt payloads or stall the writer under heavy GC pressure.
- Hardened the `runParallelizedWithClients` test harness in `go/integTest/glide_test_suite_test.go` with an `atomic.Int32` stop flag so goroutines exit on timeout instead of outliving the test and reporting late failures.
- Added a CHANGELOG entry under Fixes linking PR #6985.

## Risk Assessment

✅ Low: Small, well-bounded FFI GC-lifetime fix whose KeepAlive placement is verified correct against the Rust FFI contract (args copied synchronously before the async task spawns), covering all affected call sites, plus a minimal test-harness stop-flag and a CHANGELOG link.

## Testing

Built the Rust FFI static library and protobuf with `make build`, then ran the exact issue-#5990 flaky test `TestGlideTestSuite/TestParallelizedSetWithGC` against real standalone and cluster Valkey servers auto-started by cluster_manager.py. The test drives 640 goroutines that each call runtime.GC() before a SET through the FFI C.command boundary where the GC use-after-free would surface; it passed cleanly on both glide.Client (15.21s under load) and glide.ClusterClient with zero failures, and the ported atomic.Int32 stop-flag harness change compiled and executed without regression. Go's -asan is unsupported on darwin/arm64 so local AddressSanitizer validation was not possible; the intent records that a prior pipeline already validated this exact test cleanly under ASAN on Linux CI, so the local run confirms the functional reproduction. No UI surface is involved; evidence is the CLI test transcript. Transient build outputs are gitignored and the one incidental ffi/Cargo.lock change was restored, leaving the working tree clean.

<details>
<summary>Evidence: TestParallelizedSetWithGC pass transcript</summary>

<code>=== RUN TestGlideTestSuite/TestParallelizedSetWithGC&#10;=== RUN TestGlideTestSuite/TestParallelizedSetWithGC/glide.Client&#10;=== RUN TestGlideTestSuite/TestParallelizedSetWithGC/glide.ClusterClient&#10;--- PASS: TestGlideTestSuite (69.70s)&#10;--- PASS: TestGlideTestSuite/TestParallelizedSetWithGC (15.24s)&#10;--- PASS: TestGlideTestSuite/TestParallelizedSetWithGC/glide.Client (15.21s)&#10;--- PASS: TestGlideTestSuite/TestParallelizedSetWithGC/glide.ClusterClient (0.00s)&#10;PASS&#10;ok github.com/valkey-io/valkey-glide/go/v2/integTest 70.405s</code>

```text
=== RUN   TestGlideTestSuite
    glide_test_suite_test.go:117: Detected server version = 9.0.1
=== RUN   TestGlideTestSuite/TestParallelizedSetWithGC
=== RUN   TestGlideTestSuite/TestParallelizedSetWithGC/glide.Client
=== RUN   TestGlideTestSuite/TestParallelizedSetWithGC/glide.ClusterClient
--- PASS: TestGlideTestSuite (69.70s)
    --- PASS: TestGlideTestSuite/TestParallelizedSetWithGC (15.24s)
        --- PASS: TestGlideTestSuite/TestParallelizedSetWithGC/glide.Client (15.21s)
        --- PASS: TestGlideTestSuite/TestParallelizedSetWithGC/glide.ClusterClient (0.00s)
PASS
ok  	github.com/valkey-io/valkey-glide/go/v2/integTest	70.405s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -v ./integTest/... -run &#39;TestGlideTestSuite/TestParallelizedSetWithGC&#39; -testify.m TestParallelizedSetWithGC` — passed (standalone glide.Client 15.21s under GC pressure, glide.ClusterClient, real servers via cluster_manager.py)</code>
- <code>`make build` — built libglide_ffi.a, C bindings, and protobuf; `go build ./...` succeeded</code>
- <code>Attempted Makefile ASAN path `go test -asan`; unsupported on darwin/arm64 so ran functionally instead</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
