### PR TITLE
fix(core): accept max_total concurrent scopes, not max_total - 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+* Core: A scope pool configured with `max_total = N` now permits N concurrent scopes instead of N-1. The pool reserved a slot against `max_total` and the caller then re-checked capacity after that reservation, so the last acquire was never given a connection and the borrower timed out ([#6795](https://github.com/valkey-io/valkey-glide/issues/6795))
 * Java: Map the Jedis compatibility layer's database selection onto GLIDE's `databaseId` instead of logging a warning and discarding it. A `JedisPool` configured for a non-zero database ran every command against database 0, silently writing to a database the caller did not ask for ([#6994](https://github.com/valkey-io/valkey-glide/issues/6994))
 * Core: Mark `PSUBSCRIBE` and `PUNSUBSCRIBE` as readonly commands so cluster routing treats them consistently with `SUBSCRIBE`/`UNSUBSCRIBE` ([#6756](https://github.com/valkey-io/valkey-glide/pull/6756))
 * Core/FFI: Scoped connections honor blocking-command timeouts (e.g. `BLPOP key 0` blocks instead of timing out at the request timeout), and a scoped connection whose blocking command timed out or was cancelled is discarded on release instead of being reused with a stale server-side waiter ([#6780](https://github.com/valkey-io/valkey-glide/issues/6780), [#6794](https://github.com/valkey-io/valkey-glide/issues/6794))

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -797,10 +797,10 @@ pub struct ScopePool {
     pub configured_database_id: u32,
 }
 
-/// Outcome of [`ScopePool::try_acquire`], which solely owns the `max_total`
-/// reservation. A caller that re-checks `total_count` against `max_total` after
-/// seeing `Reserved` rejects the last slot, because the reservation is already
-/// counted by then.
+/// Outcome of [`ScopePool::try_acquire`], which owns the `max_total` reservation
+/// for the acquire path (prewarm currently seats connections without reserving).
+/// A caller that re-checks `total_count` against `max_total` after seeing
+/// `Reserved` rejects the last slot, because the reservation is already counted.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ScopeAcquire {
     /// An idle connection was reused; carries its scope id.

--- a/glide-core/src/pool.rs
+++ b/glide-core/src/pool.rs
@@ -797,6 +797,21 @@ pub struct ScopePool {
     pub configured_database_id: u32,
 }
 
+/// Outcome of [`ScopePool::try_acquire`], which solely owns the `max_total`
+/// reservation. A caller that re-checks `total_count` against `max_total` after
+/// seeing `Reserved` rejects the last slot, because the reservation is already
+/// counted by then.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScopeAcquire {
+    /// An idle connection was reused; carries its scope id.
+    Reused(u64),
+    /// A slot was reserved against `max_total`; the caller must create a
+    /// connection to fill it.
+    Reserved,
+    /// No idle connection and the pool is at `max_total`.
+    Exhausted,
+}
+
 impl ScopePool {
     pub fn new(
         config: ScopePoolConfig,
@@ -833,10 +848,14 @@ impl ScopePool {
         allocate_scope_id()
     }
 
-    /// Non-blocking acquire. Returns scope_id >= 0, -1 if exhausted.
-    pub fn try_acquire(&mut self, registry: &DashMap<u64, ScopeEntry>, routing_slot: u16) -> i64 {
+    /// Non-blocking acquire. See [`ScopeAcquire`].
+    pub fn try_acquire(
+        &mut self,
+        registry: &DashMap<u64, ScopeEntry>,
+        routing_slot: u16,
+    ) -> ScopeAcquire {
         if self.state.load(Ordering::Acquire) != POOL_RUNNING {
-            return -1;
+            return ScopeAcquire::Exhausted;
         }
 
         // Scan idle connections for one matching the requested routing slot.
@@ -876,13 +895,15 @@ impl ScopePool {
                 },
             );
             self.in_use.insert(scope_id, ());
-            return scope_id as i64;
+            return ScopeAcquire::Reused(scope_id);
         }
 
         if self.total_count.load(Ordering::Acquire) < self.config.max_total {
             self.total_count.fetch_add(1, Ordering::AcqRel);
+            ScopeAcquire::Reserved
+        } else {
+            ScopeAcquire::Exhausted
         }
-        -1
     }
 
     /// Release a scope. Zero-cost if state is clean.
@@ -1248,5 +1269,43 @@ mod connection_state_tests {
             ..Default::default()
         };
         assert!(!blocking_only.is_clean_for(CONFIGURED_DB));
+    }
+}
+
+#[cfg(test)]
+mod scope_pool_tests {
+    use super::{DashMap, Ordering, ScopeAcquire, ScopeEntry, ScopePool, ScopePoolConfig};
+
+    /// `max_total = N` must grant exactly N reservations before reporting
+    /// exhaustion. The slot is counted as the reservation is granted, so the Nth is
+    /// the one an off-by-one drops.
+    #[test]
+    fn reserves_exactly_max_total_slots() {
+        for max_total in [1_u32, 2, 64] {
+            let config = ScopePoolConfig {
+                max_total,
+                ..ScopePoolConfig::default()
+            };
+            let mut pool = ScopePool::new(config, Vec::new(), 1);
+            let registry: DashMap<u64, ScopeEntry> = DashMap::new();
+
+            for slot in 0..max_total {
+                assert_eq!(
+                    pool.try_acquire(&registry, 0),
+                    ScopeAcquire::Reserved,
+                    "max_total={max_total}: reservation {slot} must be granted"
+                );
+            }
+            assert_eq!(
+                pool.try_acquire(&registry, 0),
+                ScopeAcquire::Exhausted,
+                "max_total={max_total}: only N reservations fit"
+            );
+            assert_eq!(
+                pool.total_count.load(Ordering::Acquire),
+                max_total,
+                "max_total={max_total}: a rejected acquire must not reserve"
+            );
+        }
     }
 }

--- a/glide-core/src/scope.rs
+++ b/glide-core/src/scope.rs
@@ -24,7 +24,7 @@ use crate::pool::{
 use redis::{Cmd, RedisError, RedisResult, Value};
 
 #[cfg(feature = "proto")]
-use crate::pool::{ConnectionState, POOL_RUNNING, ScopePool};
+use crate::pool::{ConnectionState, POOL_RUNNING, ScopeAcquire, ScopePool};
 #[cfg(feature = "proto")]
 use std::sync::Arc;
 #[cfg(feature = "proto")]
@@ -578,13 +578,14 @@ pub fn try_acquire_scope(
     let registry = get_scope_registry();
 
     match scope_pool.try_lock() {
-        Ok(mut pool) => {
-            let result = pool.try_acquire(registry, routing_slot);
-            if result >= 0 {
+        Ok(mut pool) => match pool.try_acquire(registry, routing_slot) {
+            ScopeAcquire::Reused(scope_id) => {
                 let _ = telemetrylib::GlideOpenTelemetry::record_scope_acquire();
+                scope_id as i64
             }
-            if result < 0 && pool.total_count.load(Ordering::Acquire) < pool.config.max_total {
-                // Spawn background connection creation
+            ScopeAcquire::Reserved => {
+                // Fill the slot try_acquire reserved. The caller retries and picks
+                // the connection up once it lands in the idle queue.
                 let pool_clone = scope_pool.clone();
                 let conn_bytes = pool.connection_request_bytes.clone();
                 let parent_client_id = pool.parent_client_id;
@@ -594,9 +595,10 @@ pub fn try_acquire_scope(
                     create_scope_connection(pool_clone, client.as_ref(), &conn_bytes, target_slot)
                         .await;
                 });
+                -1
             }
-            result
-        }
+            ScopeAcquire::Exhausted => -1,
+        },
         Err(_) => -1,
     }
 }
@@ -680,13 +682,14 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::sync::mpsc::{self, Sender};
     use std::thread::JoinHandle;
+    use std::time::{Duration, Instant};
 
     use protobuf::Message as _;
     use tokio::sync::Mutex as TokioMutex;
 
-    use super::create_scope_connection;
+    use super::{create_scope_connection, try_acquire_scope};
     use crate::connection_request::{ConnectionRequest, NodeAddress};
-    use crate::pool::{ScopePool, ScopePoolConfig};
+    use crate::pool::{ScopePool, ScopePoolConfig, get_client_scope_pools};
 
     fn request_bytes(lib_name: &str, port: u16) -> Vec<u8> {
         let mut request = ConnectionRequest::new();
@@ -784,6 +787,65 @@ mod tests {
             shutdown_sender.send(()).expect("stop mock server");
             server.join().expect("mock server exits cleanly");
         }
+    }
+
+    /// Polls the listener, awaiting between attempts so the spawned creation task
+    /// gets to run on a current-thread runtime.
+    async fn accept_within(listener: &TcpListener, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok(_) => return true,
+                Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(e) => panic!("unexpected listener error: {e}"),
+            }
+        }
+        false
+    }
+
+    /// `max_total = N` must permit N concurrent scopes, which means the Nth
+    /// reservation has to be filled like any other. `max_total = 1` makes the very
+    /// first acquire that boundary case: the pool reserves the only slot, so a
+    /// caller that re-checks capacity after the reservation sees the pool already
+    /// full, never creates the connection, and the borrower times out.
+    #[tokio::test]
+    async fn acquire_creates_the_connection_for_the_final_slot() {
+        let listener = listening_endpoint();
+        let port = listener.local_addr().expect("listener address").port();
+        let request_bytes = request_bytes("GlideRust", port);
+
+        let client_id = 67_950_000_u64;
+        let config = ScopePoolConfig {
+            max_total: 1,
+            ..ScopePoolConfig::default()
+        };
+        get_client_scope_pools().insert(
+            client_id,
+            Arc::new(TokioMutex::new(ScopePool::new(
+                config,
+                request_bytes.clone(),
+                client_id,
+            ))),
+        );
+
+        let acquired = try_acquire_scope(
+            client_id,
+            request_bytes.clone(),
+            &tokio::runtime::Handle::current(),
+            0,
+        );
+        get_client_scope_pools().remove(&client_id);
+
+        assert_eq!(
+            acquired, -1,
+            "no idle connection yet, so the caller retries"
+        );
+        assert!(
+            accept_within(&listener, Duration::from_secs(5)).await,
+            "reserving the last slot must still create its connection"
+        );
     }
 
     /// Mirrors the poison predicate from `execute_scope_command` directly against

--- a/glide-core/tests/test_client.rs
+++ b/glide-core/tests/test_client.rs
@@ -1575,17 +1575,16 @@ pub(crate) mod shared_client_tests {
 
             let scope_id = {
                 let mut guard = pool.lock().await;
-                guard.try_acquire(glide_core::pool::get_scope_registry(), routing_slot)
+                match guard.try_acquire(glide_core::pool::get_scope_registry(), routing_slot) {
+                    glide_core::pool::ScopeAcquire::Reused(scope_id) => scope_id,
+                    other => panic!("failed to acquire scope (connection not seated): {other:?}"),
+                }
             };
-            assert!(
-                scope_id >= 0,
-                "failed to acquire scope (connection not seated): {scope_id}"
-            );
 
             ScopeHandle {
                 client,
                 client_id,
-                scope_id: scope_id as u64,
+                scope_id,
                 pool,
                 released: std::cell::Cell::new(false),
             }
@@ -1613,6 +1612,97 @@ pub(crate) mod shared_client_tests {
         fn drop(&mut self) {
             self.release();
         }
+    }
+
+    /// Polls `try_acquire_scope` the way the bindings do (see `GlideClient`'s
+    /// `scopedConnection` loop), returning `None` if the deadline passes.
+    #[cfg(feature = "proto")]
+    async fn acquire_scope_within(
+        client_id: u64,
+        bytes: &[u8],
+        timeout: std::time::Duration,
+    ) -> Option<u64> {
+        let runtime = tokio::runtime::Handle::current();
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            let result =
+                glide_core::scope::try_acquire_scope(client_id, bytes.to_vec(), &runtime, 0);
+            if result >= 0 {
+                return Some(result as u64);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        None
+    }
+
+    /// `max_total = N` must permit exactly N concurrent scopes, with N+1 the first
+    /// rejection. Exercises the whole borrow path against a real server — reserve,
+    /// create, reuse, and `in_use` accounting — which the reservation-layer unit
+    /// test in `pool.rs` cannot reach on its own.
+    #[cfg(feature = "proto")]
+    #[rstest]
+    #[serial_test::serial]
+    fn test_scope_pool_permits_exactly_max_total_concurrent_scopes() {
+        const MAX_TOTAL: u32 = 3;
+
+        block_on_all(async {
+            let configuration = TestConfiguration {
+                shared_server: true,
+                ..Default::default()
+            };
+            let test_basics = setup_test_basics(false, configuration.clone()).await;
+            let bytes = scope_request_bytes(&test_basics.server, &configuration);
+
+            let client_id = 67_950_001_u64;
+            glide_core::scope::register_client(client_id, test_basics.client.clone());
+            glide_core::pool::get_client_scope_pools().insert(
+                client_id,
+                std::sync::Arc::new(tokio::sync::Mutex::new(glide_core::pool::ScopePool::new(
+                    glide_core::pool::ScopePoolConfig {
+                        max_total: MAX_TOTAL,
+                        ..Default::default()
+                    },
+                    bytes.clone(),
+                    client_id,
+                ))),
+            );
+
+            let mut held = Vec::new();
+            for i in 0..MAX_TOTAL {
+                let scope_id =
+                    acquire_scope_within(client_id, &bytes, std::time::Duration::from_secs(10))
+                        .await
+                        .unwrap_or_else(|| {
+                            panic!("scope {} of {MAX_TOTAL} must be acquirable", i + 1)
+                        });
+                held.push(scope_id);
+            }
+
+            let over_capacity =
+                acquire_scope_within(client_id, &bytes, std::time::Duration::from_millis(500))
+                    .await;
+
+            let runtime = tokio::runtime::Handle::current();
+            for scope_id in &held {
+                glide_core::scope::release_scope(*scope_id, client_id, &runtime);
+            }
+            glide_core::scope::unregister_client(client_id);
+            glide_core::pool::get_client_scope_pools().remove(&client_id);
+
+            let mut distinct = held.clone();
+            distinct.sort_unstable();
+            distinct.dedup();
+            assert_eq!(
+                distinct.len(),
+                MAX_TOTAL as usize,
+                "each concurrent scope must get its own connection, got {held:?}"
+            );
+            assert!(
+                over_capacity.is_none(),
+                "scope {} must be rejected while {MAX_TOTAL} are held, got {over_capacity:?}",
+                MAX_TOTAL + 1
+            );
+        });
     }
 
     #[rstest]


### PR DESCRIPTION
### Summary

A scope pool configured with `max_total = N` only allowed N-1 concurrent scopes. The Nth borrower never got a connection and timed out with "Timed out waiting for isolated scope (pool exhausted)" despite the pool being below its configured capacity.

Two layers both gated on `max_total`. `ScopePool::try_acquire` reserved a slot by incrementing `total_count` and returned `-1`; `try_acquire_scope` then re-checked `total_count < max_total` before spawning connection creation. Because the reservation was already counted, that second check failed on the last slot and no connection was ever created for it.

### Issue link

Closes #6795

### Features / Behaviour Changes

- A scope pool configured with `max_total = N` now permits N concurrent scopes; the N+1st acquire is the first rejection.
- No change to the FFI/binding contract: `glide_scope_try_acquire` and `scope::try_acquire_scope` still return a scope id `>= 0` or `-1` to retry, so no binding changes are required.

### Implementation

- `ScopePool::try_acquire` now returns an explicit `ScopeAcquire` outcome (`Reused(scope_id)` / `Reserved` / `Exhausted`) instead of an `i64` where `-1` meant both "a slot was reserved, please create a connection" and "the pool is full, reject". It is now the sole owner of the `max_total` reservation.
- `try_acquire_scope`'s duplicate capacity check is **removed** rather than corrected, so the two layers can no longer drift back into disagreeing about capacity.

Note on the issue's suggested fix: it offers "let the creation path proceed when `total_count <= max_total`" as an alternative. That would be incorrect — because the old `-1` conflated the reserved and full cases, `<=` also spawns creation when the pool is genuinely at capacity. Distinguishing the two cases is what makes the fix correct, which is why the return type changed.

`ScopePool::try_acquire`'s only callers are `try_acquire_scope` and the `ScopeHandle` test harness, both updated. The similarly-named `ClientPool::try_acquire()` is a different method and is untouched.

### Limitations

- Does not address #6966 (scope-pool exhaustion after a scope to a paused/unreachable shard); root-cause findings from this investigation are noted there.
- The capacity boundary is covered in standalone mode only. The defect is topology-independent counter arithmetic, and cluster coverage would touch the slot-0 matching behaviour being changed in #6975.

### Testing

Three tests, A-B validated by reintroducing the duplicate gate:

- `test_scope_pool_permits_exactly_max_total_concurrent_scopes` (`tests/test_client.rs`) — the regression test for this issue. Against a real server with `max_total = 3`, holds 3 concurrent scopes and asserts the 4th is rejected, driving the same poll loop the bindings use. Fails on the pre-fix code with `scope 3 of 3 must be acquirable`, the direct analogue of the reported 64→63.
- `acquire_creates_the_connection_for_the_final_slot` (`src/scope.rs`) — isolates the mechanism. With `max_total = 1` the very first acquire is the boundary case; asserts a connection attempt actually reaches a listener. Fails on the pre-fix code (no connection is ever attempted).
- `reserves_exactly_max_total_slots` (`src/pool.rs`) — the `max_total` = 1 / 2 / 64 boundary coverage the issue asks for. This one passes on the pre-fix code and does not catch this bug, since the old `try_acquire` reserved correctly and the faulty gate was in its caller. It guards future drift in `try_acquire`'s own gate, not this regression.

Not covered, deliberately: the capacity boundary is only exercised in standalone mode. The defect is topology-independent counter arithmetic, and adding cluster coverage would touch the slot-0 matching behaviour that #6975 is actively changing.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`make *-lint` targets) and Prettier has been run (`make prettier-fix`).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary