### PR TITLE
fix(core): add credentials_provider to IAM test call sites

### DIFF
--- a/glide-core/src/client/mod.rs
+++ b/glide-core/src/client/mod.rs
@@ -4069,6 +4069,7 @@ mod tests {
             "us-east-1".to_string(),
             crate::iam::ServiceType::ElastiCache,
             None,
+            None,
         )
         .await
         .expect("IAMTokenManager creation should succeed with fake credentials");
@@ -4097,6 +4098,7 @@ mod tests {
                     region: "us-east-1".to_string(),
                     service_type: crate::iam::ServiceType::ElastiCache,
                     refresh_interval_seconds: None,
+                    credentials_provider: None,
                 }),
             }),
             ..Default::default()


### PR DESCRIPTION
### Summary

`main` fails to compile: `cargo build --tests` errors in `glide-core/src/client/mod.rs` with `E0061` (`IAMTokenManager::new` takes 6 arguments, 5 supplied) and `E0063` (`IamAuthenticationConfig` missing `credentials_provider`).

#6825 added the parameter and field; #7022 merged afterwards with two tests written against the old signatures. Neither touched the other's lines, so the merge was clean but left `main` broken. This updates both call sites.